### PR TITLE
Adding custom validators support

### DIFF
--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -8,10 +8,10 @@ class Schema(dict):
     Makes a Schema object from a schema dict.
     Still acts like a dict.
     """
-    def __init__(self, schema_dict, name=''):
+    def __init__(self, schema_dict, name='', validators=val.DefaultValidators):
         schema = util.flatten(schema_dict)
         dict.__init__(self, schema)
-        self._process_schema(self)
+        self._process_schema(self, validators)
         self.dict = schema_dict
         self.name = name
         self.includes = {}
@@ -21,7 +21,7 @@ class Schema(dict):
             t = Schema(custom_type, name=include_name)
             self.includes[include_name] = t
 
-    def _process_schema(self, schema):
+    def _process_schema(self, schema, validators):
         '''
         Warning: this method mutates input.
 
@@ -29,7 +29,7 @@ class Schema(dict):
         '''
         for key, expression in schema.items():
             try:
-                schema[key] = syntax.parse(expression)
+                schema[key] = syntax.parse(expression, validators)
             except SyntaxError as e:
                 # Tack on some more context and rethrow.
                 raise SyntaxError(str(e) + ' at node \'%s\'' % key)

--- a/yamale/syntax/tests/test_parser.py
+++ b/yamale/syntax/tests/test_parser.py
@@ -1,27 +1,35 @@
 from pytest import raises
 
 from .. import parser as par
-from ...validators.validators import (String, Number, Integer, Boolean, List)
-
+from ...validators.validators import (Validator, String, Number, Integer, Boolean, List)
+from ...validators import DefaultValidators
 
 def test_eval():
     assert eval('String()') == String()
 
 
 def test_types():
-    assert par.parse('String()') == String()
-    assert par.parse('str()') == String()
-    assert par.parse('num()') == Number()
-    assert par.parse('int()') == Integer()
-    assert par.parse('bool()') == Boolean()
-    assert par.parse('list(str())') == List(String())
+    assert par.parse('String()', DefaultValidators) == String()
+    assert par.parse('str()', DefaultValidators) == String()
+    assert par.parse('num()', DefaultValidators) == Number()
+    assert par.parse('int()', DefaultValidators) == Integer()
+    assert par.parse('bool()', DefaultValidators) == Boolean()
+    assert par.parse('list(str())', DefaultValidators) == List(String())
+
+
+def test_custom_type():
+
+    class my_validator(Validator):
+        pass
+
+    assert par.parse('custom()', {'custom': my_validator}) == my_validator()
 
 
 def test_required():
-    assert par.parse('str(required=True)').is_required
-    assert par.parse('str(required=False)').is_optional
+    assert par.parse('str(required=True)', DefaultValidators).is_required
+    assert par.parse('str(required=False)', DefaultValidators).is_optional
 
 
 def test_syntax_error():
     with raises(SyntaxError):
-        par.parse('eval()')
+        par.parse('eval()', DefaultValidators)

--- a/yamale/tests/meta_test_fixtures/data_custom.yaml
+++ b/yamale/tests/meta_test_fixtures/data_custom.yaml
@@ -1,0 +1,2 @@
+string: custom data - date
+custom: 2015-01-01

--- a/yamale/tests/meta_test_fixtures/schema_custom.yaml
+++ b/yamale/tests/meta_test_fixtures/schema_custom.yaml
@@ -1,0 +1,3 @@
+string: str()
+number: num(required=False)
+custom: date(required=False)

--- a/yamale/tests/test_meta_test.py
+++ b/yamale/tests/test_meta_test.py
@@ -1,5 +1,8 @@
+import datetime
 import os
 from yamale import YamaleTestCase
+from yamale.validators import add_default_validator, Validator
+
 
 data_folder = os.path.dirname(os.path.realpath(__file__))
 
@@ -31,4 +34,24 @@ class TestListYaml(YamaleTestCase):
             'meta_test_fixtures/schema.yaml']
 
     def runTest(self):
+        self.assertTrue(self.validate())
+
+
+class Date(Validator):
+    """Custom validator for testing purpose
+    """
+    tag = 'date'
+
+    def _is_valid(self, value):
+        return isinstance(value, datetime.date)
+
+
+class TestCustomValidator(YamaleTestCase):
+    base_dir = data_folder
+    schema = 'meta_test_fixtures/schema_custom.yaml'
+    yaml = ['meta_test_fixtures/data*.yaml',
+            'meta_test_fixtures/data_custom.yaml']
+
+    def runTest(self):
+        add_default_validator(Date)
         self.assertTrue(self.validate())

--- a/yamale/validators/__init__.py
+++ b/yamale/validators/__init__.py
@@ -1,4 +1,11 @@
 from .base import Validator
 from .validators import *
 
-TYPES = Validator.__subclasses__()
+DefaultValidators = {}
+def add_default_validator(validator):
+    # Allow validator nodes to contain either tags or actual name
+    DefaultValidators[validator.tag] = validator
+    DefaultValidators[validator.__name__] = validator
+
+for v in Validator.__subclasses__():
+    add_default_validator(v)


### PR DESCRIPTION
Hi,

My name is Lionel and I'm working at a french firm called Polyconseil. I found your yamale library the other day, and it is really well made. Yamale could be very useful for our new YAML configuration architecture. I took the liberty to make this pull request to add a feature we need : the ability to add some custom validators to the default yamale validators. I used a pretty simple "date" validator for testing purpose, but we have other custom format we would like to validate, which can not be added to the default validators because they are not so standard. I hope I'll have the opportunity to make some other PRs in the near future to help and improve this nice tool.

Kind Regards