### PR TITLE
Fix included lists

### DIFF
--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -65,7 +65,7 @@ class Schema(object):
             position = key
 
         try:  # Pull value out of data. Data can be a map or a list/sequence
-            data_item = data[key]
+            data_item = util.get_value(data, key)
         except KeyError:  # Oops, that field didn't exist.
             if validator.is_optional:  # Optional? Who cares.
                 return errors

--- a/yamale/schema/util.py
+++ b/yamale/schema/util.py
@@ -1,4 +1,5 @@
 from collections import Mapping, Set, Sequence
+from operator import getitem
 
 # Python 3 has no basestring, lets test it.
 try:
@@ -9,6 +10,13 @@ try:
 except NameError:
     def isstr(s):
         return isinstance(s, str)
+
+# Python 3 has displaced reduce, lets test it.
+try:
+    reduce = reduce # attempt to evaluate reduce
+except NameError:
+    import functools
+    reduce = functools.reduce
 
 
 def flatten(dic, keep_iter=False, position=None):
@@ -34,6 +42,32 @@ def flatten(dic, keep_iter=False, position=None):
             child[item_position] = v
 
     return child
+
+
+def get_expanded_path(dic, key):
+    path = []
+    cur = dic
+    try:
+        keys = key.split('.')
+    except AttributeError:
+        keys = [key]
+    for k in keys[:-1]:
+        try:
+            cur = cur[k]
+            path.append(k)
+        except TypeError:
+            k = int(k)
+            cur = cur[k]
+            path.append(k)
+    return path, keys[-1]
+
+
+def get_value(dic, key):
+    path, last_key = get_expanded_path(dic, key)
+    try:
+        return reduce(getitem, path, dic)[last_key]
+    except TypeError:
+        return reduce(getitem, path, dic)[int(last_key)]
 
 
 def is_iter(obj):

--- a/yamale/tests/meta_test_fixtures/data_include_list.yaml
+++ b/yamale/tests/meta_test_fixtures/data_include_list.yaml
@@ -1,0 +1,5 @@
+included_list:
+- - first
+  - 2
+- - third
+  - 2004-04-04

--- a/yamale/tests/meta_test_fixtures/schema_include_list.yaml
+++ b/yamale/tests/meta_test_fixtures/schema_include_list.yaml
@@ -1,0 +1,7 @@
+included_list: include('my_list')
+---
+my_list:
+- - str()
+  - int()
+- - str()
+  - day()

--- a/yamale/tests/test_meta_test.py
+++ b/yamale/tests/test_meta_test.py
@@ -25,13 +25,22 @@ class TestBadYaml(YamaleTestCase):
         self.assertRaises(ValueError, self.validate)
 
 
-class TestListYaml(YamaleTestCase):
+class TestMapYaml(YamaleTestCase):
     base_dir = data_folder
     schema = 'meta_test_fixtures/schema.yaml'
     yaml = ['meta_test_fixtures/data_custom.yaml',
             'meta_test_fixtures/some_data.yaml',
             # Make sure  schema doesn't validate itself
             'meta_test_fixtures/schema.yaml']
+
+    def runTest(self):
+        self.assertTrue(self.validate())
+
+
+class TestListYaml(YamaleTestCase):
+    base_dir = data_folder
+    schema = 'meta_test_fixtures/schema_include_list.yaml'
+    yaml = ['meta_test_fixtures/data_include_list.yaml']
 
     def runTest(self):
         self.assertTrue(self.validate())

--- a/yamale/validators/validators.py
+++ b/yamale/validators/validators.py
@@ -121,7 +121,7 @@ class Include(Validator):
         super(Include, self).__init__(*args, **kwargs)
 
     def _is_valid(self, value):
-        return isinstance(value, Mapping)
+        return isinstance(value, Mapping) or isinstance(value, Sequence)
 
     def get_name(self):
         return self.include_name


### PR DESCRIPTION
I added a test which fails: when multi-level lists are included, elements cannot be retrieved using the keys "0.0", "0.1" etc…
I propose a fix to handle these kind of cases, which can be part of a valid schema. 