### PR TITLE
Merge #23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ var/
 .installed.cfg
 *.egg
 
+# IDE dot directories
+.idea/
+.ropeproject/
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/yamale/schema/data.py
+++ b/yamale/schema/data.py
@@ -1,4 +1,4 @@
-from . import util
+from .. import util
 
 
 class Data(dict):

--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -1,5 +1,4 @@
-from .. import syntax
-from . import util
+from .. import syntax, util
 from .. import validators as val
 
 

--- a/yamale/syntax/tests/test_parser.py
+++ b/yamale/syntax/tests/test_parser.py
@@ -1,8 +1,8 @@
 from pytest import raises
 
 from .. import parser as par
-from ...validators.validators import (Validator, String, Number,
-                                      Integer, Boolean, List, Day, Timestamp)
+from yamale.validators.validators import (
+    Validator, String, Number, Integer, Boolean, List, Day, Timestamp)
 
 
 def test_eval():

--- a/yamale/tests/test_functional.py
+++ b/yamale/tests/test_functional.py
@@ -69,7 +69,7 @@ for d in test_data:
 
 
 def test_tests():
-    ''' Make sure the test runner is working.'''
+    """ Make sure the test runner is working."""
     assert 1 + 1 == 2
 
 

--- a/yamale/util.py
+++ b/yamale/util.py
@@ -1,3 +1,4 @@
+import sys
 from collections import Mapping, Set, Sequence
 from operator import getitem
 from functools import reduce
@@ -86,3 +87,39 @@ def get_iter(iterable):
         return iterable.items()
     else:
         return enumerate(iterable)
+
+
+def get_subclasses(cls, _subclasses_yielded=None):
+    """
+    Generator recursively yielding all subclasses of the passed class (in
+    depth-first order).
+
+    Parameters
+    ----------
+    cls : type
+        Class to find all subclasses of.
+    _subclasses_yielded : set
+        Private parameter intended to be passed only by recursive invocations of
+        this function, containing all previously yielded classes.
+    """
+
+    if _subclasses_yielded is None:
+        _subclasses_yielded = set()
+
+    # If the passed class is old- rather than new-style, raise an exception.
+    if not hasattr(cls, '__subclasses__'):
+        raise TypeError('Old-style class "%s" unsupported.' % cls.__name__)
+
+    # For each direct subclass of this class
+    for subclass in cls.__subclasses__():
+        # If this subclass has already been yielded, skip to the next.
+        if subclass in _subclasses_yielded:
+            continue
+
+        # Yield this subclass and record having done so before recursing.
+        yield subclass
+        _subclasses_yielded.add(subclass)
+
+        # Yield all direct subclasses of this class as well.
+        for subclass_subclass in get_subclasses(subclass, _subclasses_yielded):
+            yield subclass_subclass

--- a/yamale/validators/tests/test_constraint.py
+++ b/yamale/validators/tests/test_constraint.py
@@ -1,5 +1,5 @@
 import datetime
-from ... import validators as val
+from yamale import validators as val
 
 
 def test_length_min():

--- a/yamale/validators/tests/test_validate.py
+++ b/yamale/validators/tests/test_validate.py
@@ -1,5 +1,13 @@
 from datetime import date, datetime
-from ... import validators as val
+from yamale import validators as val
+
+
+def test_validator_defaults():
+    """
+    Unit test the dictionary of default validators.
+    """
+    assert val.DefaultValidators[val.String.tag] is val.String
+    assert val.DefaultValidators[val.Any.__name__] is val.Any
 
 
 def test_equality():

--- a/yamale/validators/validators.py
+++ b/yamale/validators/validators.py
@@ -1,18 +1,8 @@
-from collections import Set, Sequence, Mapping
+from collections import Sequence, Mapping
 from datetime import date, datetime
 from .base import Validator
 from . import constraints as con
-
-
-# Python 3 has no basestring, lets test it.
-try:
-    basestring  # attempt to evaluate basestring
-
-    def isstr(s):
-        return isinstance(s, basestring)
-except NameError:
-    def isstr(s):
-        return isinstance(s, str)
+from .. import util
 
 
 class String(Validator):
@@ -21,7 +11,7 @@ class String(Validator):
     constraints = [con.LengthMin, con.LengthMax, con.CharacterExclude]
 
     def _is_valid(self, value):
-        return isstr(value)
+        return util.isstr(value)
 
 
 class Number(Validator):
@@ -109,7 +99,7 @@ class List(Validator):
         self.validators = [val for val in args if isinstance(val, Validator)]
 
     def _is_valid(self, value):
-        return isinstance(value, Sequence) and not isstr(value)
+        return isinstance(value, Sequence) and not util.isstr(value)
 
 
 class Include(Validator):
@@ -121,7 +111,7 @@ class Include(Validator):
         super(Include, self).__init__(*args, **kwargs)
 
     def _is_valid(self, value):
-        return isinstance(value, (Mapping, Sequence)) and not isstr(value)
+        return isinstance(value, (Mapping, Sequence)) and not util.isstr(value)
 
     def get_name(self):
         return self.include_name
@@ -150,7 +140,7 @@ class Null(Validator):
 
 DefaultValidators = {}
 
-for v in Validator.__subclasses__():
+for v in util.get_subclasses(Validator):
     # Allow validator nodes to contain either tags or actual name
     DefaultValidators[v.tag] = v
     DefaultValidators[v.__name__] = v


### PR DESCRIPTION
The PyCharm-specific ".idea" dot directory and Rope-specific ".ropeproject"
dot directory are now ignored by Git.

`yamale.schema.util` moved to `yamale.util`.

The general-purpose `yamale.schema.util` module has been moved to the root
`yamale` package for use elsewhere (e.g., the `yamale.validators` subpackage).

Utility functions added.

* get_subclasses(), simplifying definition of the "DefaultValidators" dictionary.

`yamale.validators.validators.isstr()` removed.

This utility function was a duplicate of the existing `yamale.util.isstr()`
function and has thus been replaced by that.