### PR TITLE
Add silent flag to validate() to allow or disallow printing includes

### DIFF
--- a/yamale/yamale.py
+++ b/yamale/yamale.py
@@ -25,7 +25,7 @@ def make_data(path):
     return [Data(d, path) for d in raw_data]
 
 
-def validate(schema, data):
+def validate(schema, data, silent=True):
     for d in data:
-        schema.validate(d)
+        schema.validate(d, silent=silent)
     return data


### PR DESCRIPTION
Currently, when `_validate_include()` is called, included validators are printed to `stdout`. This is noisy and slows down validation for deeply nested schemas.

For example, suppose I have this schema:

```yaml
id: int(min=1)
title: str()
content: list(include('headingT'), include('paragraphT'))
---
headingT:
  heading: str()

paragraphT:
  paragraph: str()
```

and this file:

```yaml
id: 1
title: This is a title
content:
- heading: This is a heading
- paragraph: This is some text
```

Validating this file will produce the following output:

```plaintext
>>> import yamale
>>> _ = yamale.validate(yamale.make_schema('schema.yaml'), yamale.make_data('data.yaml'))
('heading', String((), {}))
('paragraph', String((), {}))
('heading', String((), {}))
('paragraph', String((), {}))
>>>
```

This change turns this off by default:

```plaintext
>>> import yamale
>>> _ = yamale.validate(yamale.make_schema('schema.yaml'), yamale.make_data('data.yaml'))
>>>
```

Pass `silent=False` to `validate()` to get the old behavior:

It's possible the `print()` ([see this line](https://github.com/23andMe/Yamale/blob/master/yamale/schema/schema.py#L141)) was just a debugging artifact, in which case, it would probably be better to just delete it.