### PR TITLE
Look for schema in different folders.

### DIFF
--- a/yamale/command_line.py
+++ b/yamale/command_line.py
@@ -28,13 +28,28 @@ def _validate(schema_path, data_path):
 
 
 def _find_schema(data_path, schema_name):
-    if not data_path or data_path == '/' or data_path == '.':
-        return None
-    directory = os.path.dirname(data_path)
-    path = glob.glob(os.path.join(directory, schema_name))
-    if not path:
-        return _find_schema(directory, schema_name)
-    return path[0]
+    '''Find if the schema file exists. If not, look for all files
+    that match the expression of "schema_name" and if no file is
+    found try the same in data_path directory. Only the first file
+    is returned. 
+    
+    Return a valid path or raise error if no file is found.'''
+
+    if os.path.isfile(schema_name):
+        return schema_name
+    else:
+        path = glob.glob(schema_name)
+        if len(path) == 0:
+            if data_path and data_path != '/' and data_path != '.':
+                directory = os.path.dirname(data_path)
+                path = glob.glob(os.path.join(directory, schema_name))
+        
+        if len(path) > 0:
+            path = [ p for p in path if os.path.isfile(p)][0]
+        else:
+            raise ValueError("Invalid schema name for '{}' or schema not found.".format(schema_name))
+
+    return path
 
 
 def _validate_single(yaml_path, schema_name):
@@ -49,7 +64,7 @@ def _validate_dir(root, schema_name, cpus):
     print('Finding yaml files...')
     for root, dirs, files in os.walk(root):
         for f in files:
-            if f.endswith('.yaml') and f != schema_name:
+            if f.endswith('.yaml') or f.endswith('.yml') and f != schema_name:
                 d = os.path.join(root, f)
                 s = _find_schema(d, schema_name)
                 if s:
@@ -67,7 +82,7 @@ def _validate_dir(root, schema_name, cpus):
 
 def _router(root, schema_name, cpus):
     root = os.path.abspath(root)
-    if root.endswith('.yaml'):
+    if root.endswith('.yaml') or root.endswith('.yml'):
         _validate_single(root, schema_name)
     else:
         _validate_dir(root, schema_name, cpus)

--- a/yamale/tests/test_command_line.py
+++ b/yamale/tests/test_command_line.py
@@ -6,13 +6,13 @@ def test_bad_yaml():
     with pytest.raises(ValueError):
         command_line._router(
             'yamale/tests/command_line_fixtures/yamls/bad.yaml',
-            'schema.yaml', 1)
+            '../schema.yaml', 1)
 
 
 def test_good_yaml():
     command_line._router(
         'yamale/tests/command_line_fixtures/yamls/good.yaml',
-        'schema.yaml', 1)
+        '../schema.yaml', 1)
 
 
 def test_bad_dir():


### PR DESCRIPTION
"schema" file was always located in the "data" directory thus preventing the user to specify different folders.

The current proposal is to perform the following steps:
  - check if "schema" is a path to an existing file (eg: "./myschema.yaml" or "/home/user/schema.yaml")
  - Else, try to see if it's an expression (eg: "./schema*.yaml" or "/home/user/schema*.yaml") and take the first valid file (no matter its extension).
  - Else, look in "data" folder for all files that match schema expression and take the first valid file.
This also make it possible to use relative paths (eg: '../schema.yaml').

When everything fails then raise an ValueError (If we have no schema, there is no validation).

__BTW__: ".yml" becomes a valid extension.