### PR TITLE
Possibility to choose which parser to use for loading files

### DIFF
--- a/yamale/readers/tests/test_bad_file.py
+++ b/yamale/readers/tests/test_bad_file.py
@@ -4,4 +4,4 @@ from .. import parse_file
 
 def test_reader_error():
     with raises(IOError):
-        parse_file('wat')
+        parse_file('wat', 'PyYAML')

--- a/yamale/readers/tests/test_yaml.py
+++ b/yamale/readers/tests/test_yaml.py
@@ -8,12 +8,12 @@ KEYWORDS = get_fixture('keywords.yaml')
 
 
 def test_parse():
-    a = yaml_reader.parse_file(TYPES)[0]
+    a = yaml_reader.parse_file(TYPES, 'PyYAML')[0]
     assert a['string'] == 'str()'
 
 
 def test_types():
-    t = yaml_reader.parse_file(TYPES)[0]
+    t = yaml_reader.parse_file(TYPES, 'PyYAML')[0]
     assert t['string'] == 'str()'
     assert t['number'] == 'num()'
     assert t['boolean'] == 'bool()'
@@ -21,10 +21,10 @@ def test_types():
 
 
 def test_keywords():
-    t = yaml_reader.parse_file(KEYWORDS)[0]
+    t = yaml_reader.parse_file(KEYWORDS, 'PyYAML')[0]
     assert t['optional_min'] == 'int(min=1, required=False)'
 
 
 def test_nested():
-    t = yaml_reader.parse_file(NESTED)[0]
+    t = yaml_reader.parse_file(NESTED, 'PyYAML')[0]
     assert t['list'][-1]['string'] == 'str()'

--- a/yamale/readers/yaml_reader.py
+++ b/yamale/readers/yaml_reader.py
@@ -1,12 +1,20 @@
 from __future__ import absolute_import
-import yaml
 
-try:
-    Loader = yaml.CSafeLoader
-except AttributeError:  # System does not have libyaml
-    Loader = yaml.SafeLoader
+def parse_file(file_name, parser):
+    if 'PyYAML' == parser:
+        import yaml
+        try:
+            Loader = yaml.CSafeLoader
+        except AttributeError:  # System does not have libyaml
+            Loader = yaml.SafeLoader
+        with open(file_name) as f:
+            return list(yaml.load_all(f, Loader=Loader))
 
+    elif 'ruamel' == parser:
+        from ruamel.yaml import YAML
+        yaml=YAML(typ='safe')
+        with open(file_name) as f:
+            return list(yaml.load_all(f))
 
-def parse_file(file_name):
-    with open(file_name) as f:
-        return list(yaml.load_all(f, Loader=Loader))
+    else:
+        raise NameError('Parser "' + parser + '" is not supported\nAvailable parsers are listed below:\nPyYAML\nruamel')

--- a/yamale/tests/test_command_line.py
+++ b/yamale/tests/test_command_line.py
@@ -8,7 +8,7 @@ def test_bad_yaml():
     try:
         command_line._router(
             'yamale/tests/command_line_fixtures/yamls/bad.yaml',
-            'schema.yaml', 1)
+            'schema.yaml', 1, 'PyYAML')
     except ValueError as e:
         assert 'map.bad: \'12.5\' is not a str.' in str(e)
         return
@@ -18,32 +18,32 @@ def test_bad_yaml():
 def test_good_yaml():
     command_line._router(
         'yamale/tests/command_line_fixtures/yamls/good.yaml',
-        'schema.yaml', 1)
+        'schema.yaml', 1, 'PyYAML')
 
 
 def test_good_relative_yaml():
     command_line._router(
         'yamale/tests/command_line_fixtures/yamls/good.yaml',
-        '../schema_dir/external.yaml', 1)
+        '../schema_dir/external.yaml', 1, 'PyYAML')
 
 
 def test_external_glob_schema():
     command_line._router(
         'yamale/tests/command_line_fixtures/yamls/good.yaml',
-        os.path.join(dir_path, 'command_line_fixtures/schema_dir/ex*.yaml'), 1)
+        os.path.join(dir_path, 'command_line_fixtures/schema_dir/ex*.yaml'), 1, 'PyYAML')
 
 
 def test_external_schema():
     command_line._router(
         'yamale/tests/command_line_fixtures/yamls/good.yaml',
-        os.path.join(dir_path, 'command_line_fixtures/schema_dir/external.yaml'), 1)
+        os.path.join(dir_path, 'command_line_fixtures/schema_dir/external.yaml'), 1, 'PyYAML')
 
 
 def test_bad_dir():
     try:
         command_line._router(
             'yamale/tests/command_line_fixtures/yamls',
-            'schema.yaml', 4)
+            'schema.yaml', 4, 'PyYAML')
     except ValueError as e:
         assert 'map.bad: \'12.5\' is not a str.' in str(e)
         return

--- a/yamale/yamale.py
+++ b/yamale/yamale.py
@@ -6,11 +6,11 @@ from .schema import Data
 PY2 = sys.version_info[0] == 2
 
 
-def make_schema(path, validators=None):
+def make_schema(path, parser='PyYAML', validators=None):
     # validators = None means use default.
     # Import readers here so we can get version information in setup.py.
     from . import readers
-    raw_schemas = readers.parse_file(path)
+    raw_schemas = readers.parse_file(path, parser)
 
     # First document is the base schema
     try:
@@ -28,9 +28,9 @@ def make_schema(path, validators=None):
     return s
 
 
-def make_data(path):
+def make_data(path, parser='PyYAML'):
     from . import readers
-    raw_data = readers.parse_file(path)
+    raw_data = readers.parse_file(path, parser)
     return [Data(d, path) for d in raw_data]
 
 


### PR DESCRIPTION
Possibility to choose between PyYAML and ruamel parsers with the optional argument `-p PARSER` or `--parser PARSER`.

PyYAML is the default parser, but does not fully support YAML 1.2.

Ruamel offers full support of YAML 1.2 and thus closes #34.