### PR TITLE
Regular expression validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,12 +208,13 @@ Validates strings against one or more regular expressions.
 - keywords:
     - `name`: A friendly description for the patterns.
     - `ignore_case`: Validates strings in a case-insensitive manner.
-    - `multiline`: `^` and `$` in a pattern match at the beginning and end of each line in a string in addition to matching at the beginning and end of the entire string.
+    - `multiline`: `^` and `$` in a pattern match at the beginning and end of each line in a string in addition to matching at the beginning and end of the entire string. (A pattern matches at [the beginning of a string](https://docs.python.org/3/library/re.html#re.match) even in multiline mode; see below for a workaround.)
     - `dotall`: `.` in a pattern matches newline characters in a validated string in addition to matching every character that *isn't* a newline.
 
 Examples:
 - `regex('^[^?!]{,10}$')`: Allows only strings less than 11 characters that don't contain `?` or `!`.
-- `regex(r'^(\d+)(\s\1)+$', name='repeated natural')`: Allows only strings that contain two or more identical digit sequences, each separated by a whitespace character. Non-matching strings like `'sugar'` are rejected with a message like `'sugar' is not a repeated natural.`
+- `regex(r'^(\d+)(\s\1)+$', name='repeated natural')`: Allows only strings that contain two or more identical digit sequences, each separated by a whitespace character. Non-matching strings like `sugar` are rejected with a message like `'sugar' is not a repeated natural.`
+- `regex('.*^apples$', multiline=True, dotall=True)`: Allows the string `apples` as well as multiline strings that contain the line `apples`.
 
 ### Integer - `int(min=int, max=int)`
 Validates integers.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,20 @@ Validates strings.
     - `exclude`: Rejects strings that contains any character in the excluded value.
 
 Examples:
-- `str(max=10, exclude='?!')`: Allows only strings less than 10 characters that don't contain `?` or `!`.
+- `str(max=10, exclude='?!')`: Allows only strings less than 11 characters that don't contain `?` or `!`.
+
+### Regex - `regex([patterns], name=string, ignore_case=False, multiline=False, dotall=False)`
+Validates strings against one or more regular expressions.
+- arguments: one or more Python regular expression patterns
+- keywords:
+    - `name`: A friendly description for the patterns.
+    - `ignore_case`: Validates strings in a case-insensitive manner.
+    - `multiline`: `^` and `$` in a pattern match at the beginning and end of each line in a string in addition to matching at the beginning and end of the entire string.
+    - `dotall`: `.` in a pattern matches newline characters in a validated string in addition to matching every character that *isn't* a newline.
+
+Examples:
+- `regex('^[^?!]{,10}$')`: Allows only strings less than 11 characters that don't contain `?` or `!`.
+- `regex(r'^(\d+)(\s\1)+$', name='repeated natural')`: Allows only strings that contain two or more identical digit sequences, each separated by a whitespace character. Non-matching strings like `'sugar'` are rejected with a message like `'sugar' is not a repeated natural.`
 
 ### Integer - `int(min=int, max=int)`
 Validates integers.

--- a/yamale/syntax/tests/test_parser.py
+++ b/yamale/syntax/tests/test_parser.py
@@ -2,7 +2,7 @@ from pytest import raises
 
 from .. import parser as par
 from yamale.validators.validators import (
-    Validator, String, Number, Integer, Boolean, List, Day, Timestamp)
+    Validator, String, Regex, Number, Integer, Boolean, List, Day, Timestamp)
 
 
 def test_eval():
@@ -12,6 +12,7 @@ def test_eval():
 def test_types():
     assert par.parse('String()') == String()
     assert par.parse('str()') == String()
+    assert par.parse('regex()') == Regex()
     assert par.parse('num()') == Number()
     assert par.parse('int()') == Integer()
     assert par.parse('day()') == Day()

--- a/yamale/tests/fixtures/regex.yaml
+++ b/yamale/tests/fixtures/regex.yaml
@@ -1,0 +1,5 @@
+uri_url_list: >
+  list(regex(r'^(?:(?:https?://)?(?:api)\.foobar\.com|foobar)([:/])'
+             r'(spam|ham|eggs)\1([a-zA-Z0-9]{10})(?:\?.*)?$'))
+
+flags: regex('^orange.*juice$', ignore_case=True, multiline=True, dotall=True)

--- a/yamale/tests/fixtures/regex_bad.yaml
+++ b/yamale/tests/fixtures/regex_bad.yaml
@@ -1,0 +1,11 @@
+uri_url_list:
+  - foobar:spim:abcde12345
+  - api.foobar.com/ham/54321edcbaZYX
+  - http://api.foobar.com/eggs:a1b2c3d4e5?derp=hello
+
+flags: >
+  ORANGE PEEL
+
+  and
+
+  LEMONS

--- a/yamale/tests/fixtures/regex_good.yaml
+++ b/yamale/tests/fixtures/regex_good.yaml
@@ -1,0 +1,11 @@
+uri_url_list:
+  - foobar:spam:abcde12345
+  - api.foobar.com/ham/54321edcba
+  - http://api.foobar.com/eggs/a1b2c3d4e5?derp=hello
+
+flags: >
+  ORANGE PEEL
+
+  and
+
+  LEMON JUICE

--- a/yamale/tests/fixtures/types.yaml
+++ b/yamale/tests/fixtures/types.yaml
@@ -1,4 +1,5 @@
 string: str()
+regex: regex('abcde')
 number: num()
 integer: int()
 boolean: bool()

--- a/yamale/tests/fixtures/types_bad_data.yaml
+++ b/yamale/tests/fixtures/types_bad_data.yaml
@@ -1,4 +1,5 @@
 string: 1
+regex: 'edcba'
 number: "nan"
 integer: 1.4
 boolean: 0

--- a/yamale/tests/fixtures/types_good_data.yaml
+++ b/yamale/tests/fixtures/types_good_data.yaml
@@ -1,4 +1,5 @@
 string: "hello"
+regex: 'abcde'
 number: 12.1
 integer: 2
 boolean: True

--- a/yamale/tests/test_functional.py
+++ b/yamale/tests/test_functional.py
@@ -56,10 +56,17 @@ issue_22 = {
     'good': 'issue_22_good.yaml'
 }
 
+regexes = {
+    'schema': 'regex.yaml',
+    'bad': 'regex_bad.yaml',
+    'good': 'regex_good.yaml'
+}
+
 test_data = [
     types, nested, custom,
     keywords, lists, maps,
-    anys, list_include, issue_22
+    anys, list_include, issue_22,
+    regexes
 ]
 
 for d in test_data:
@@ -92,7 +99,7 @@ def test_good(data_map):
 
 
 def test_bad_validate():
-    assert count_exception_lines(types['schema'], types['bad']) == 10
+    assert count_exception_lines(types['schema'], types['bad']) == 11
 
 
 def test_bad_nested():
@@ -121,6 +128,10 @@ def test_bad_keywords():
 
 def test_bad_anys():
     assert count_exception_lines(anys['schema'], anys['bad']) == 7
+
+
+def test_bad_regexes():
+    assert count_exception_lines(regexes['schema'], regexes['bad']) == 9
 
 
 def test_bad_schema():

--- a/yamale/validators/tests/test_validate.py
+++ b/yamale/validators/tests/test_validate.py
@@ -31,12 +31,28 @@ def test_string():
 
 
 def test_regex():
-    v = val.Regex(r'^(abc)\1?de$', name='test_regex')
-    assert v.is_valid('abcde')
+    v = val.Regex(r'^(abc)\1?de$', name='test regex')
     assert v.is_valid('abcabcde')
-    assert v.get_name() == 'test_regex'
-    assert not v.is_valid('abcde ')
     assert not v.is_valid('abcabcabcde')
+    assert not v.is_valid('\12')
+    assert v.fail('woopz') == '\'woopz\' is not a test regex.'
+
+    v = val.Regex('[a-z0-9]{3,}s\s$', ignore_case=True)
+    assert v.is_valid('b33S\v')
+    assert v.is_valid('B33s\t')
+    assert not v.is_valid(' b33s ')
+    assert not v.is_valid('b33s  ')
+    assert v.fail('fdsa') == '\'fdsa\' is not a regex match.'
+
+    v = val.Regex('A.+\d$', ignore_case=False, multiline=True)
+    assert v.is_valid('A_-3\n\n')
+    assert not v.is_valid('a!!!!!5\n\n')
+
+    v = val.Regex('.*^Ye.*s\.', ignore_case=True, multiline=True, dotall=True)
+    assert v.is_valid('YEeeEEEEeeeeS.')
+    assert v.is_valid('What?\nYes!\nBEES.\nOK.')
+    assert not v.is_valid('YES-TA-TOES?')
+    assert not v.is_valid('\n\nYaes.')
 
 
 def test_number():

--- a/yamale/validators/tests/test_validate.py
+++ b/yamale/validators/tests/test_validate.py
@@ -30,6 +30,15 @@ def test_string():
     assert not v.is_valid(1)
 
 
+def test_regex():
+    v = val.Regex(r'^(abc)\1?de$', name='test_regex')
+    assert v.is_valid('abcde')
+    assert v.is_valid('abcabcde')
+    assert v.get_name() == 'test_regex'
+    assert not v.is_valid('abcde ')
+    assert not v.is_valid('abcabcabcde')
+
+
 def test_number():
     v = val.Number()
     assert v.is_valid(1)


### PR DESCRIPTION
Hi, here's my stab at adding a regular expression validator. I would've created a feature request but one exists already at #40.

The default fail message was modified, because `'foo' is not a regex` didn't make any sense, but further customization of the fail message to something like `'foo' is not a User ID` may or may not be something you want.

I considered allowing regex flags to be passed to `re.compile()` by using the validator like `regex(r'pattern', [r'pattern2',] flags=re.IGNORECASE, name='eggs')`, but that looked like it would've required adding the `re` module (or at least the various flags it defines) to the allowed (very) short list of `safe_globals` in `syntax.parser`. So... never mind that. :relieved:

I also updated the README to document the validator and fix a minor inaccuracy in the existing documentation for String.

Thanks for reviewing!