### PR TITLE
Support custom YAML tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ yamale.validate(schema, data)
 
 If `data` is valid, nothing will happen. However, if `data` is invalid Yamale will throw a `ValueError` with a message containing all the invalid nodes.
 
-You can also specifiy an optional `parser` if you'd like to use the `ruamel.yaml` (YAML 1.2 support) instead:
+You can also specify an optional `parser` if you'd like to use the `ruamel.yaml` (YAML 1.2 support) instead:
 ```python
 # Import Yamale and make a schema object, make sure ruamel.yaml is installed already.
 import yamale
@@ -85,6 +85,22 @@ data = yamale.make_data('./data.yaml', parser='ruamel')
 
 # Validate data against the schema same as before.
 yamale.validate(schema, data)
+```
+
+You can include your own python constructors to support custom YAML tags.  
+**WARNING:** This enables the default yaml loader which allows arbitrary python to run through any loaded YAML files. Use at your own risk!
+```python
+import yamale
+schema = yamale.make_schema('./schema.yaml')
+
+# Create a Data object using dict of custom constructor tuple(s)
+data = yamale.make_data('./data.yaml', constructors={('!join', _joiner)})
+
+#allows join function to be called on arbitrary sequences in yaml, works with anchors and aliases
+#example: !join [root/path/, relative/path]
+def _joiner(loader, node):
+    seq = loader.construct_sequence(node)
+    return ''.join([str(i) for i in seq])
 ```
 
 ### Schema

--- a/yamale/readers/tests/test_yaml.py
+++ b/yamale/readers/tests/test_yaml.py
@@ -6,6 +6,7 @@ parsers = ['pyyaml', 'PyYAML', 'ruamel']
 TYPES = get_fixture('types.yaml')
 NESTED = get_fixture('nested.yaml')
 KEYWORDS = get_fixture('keywords.yaml')
+TAGS = get_fixture('custom_tags.yaml')
 
 
 @pytest.mark.parametrize('parser', parsers)
@@ -33,3 +34,10 @@ def test_keywords(parser):
 def test_nested(parser):
     t = yaml_reader.parse_file(NESTED, parser)[0]
     assert t['list'][-1]['string'] == 'str()'
+
+def test_custom_tags():
+    def _joiner(loader, node):
+        seq = loader.construct_sequence(node)
+        return ''.join([str(i) for i in seq])
+    t = yaml_reader.parse_file(TAGS, 'pyyaml', {('!join', _joiner)})[0]
+    assert t['dest'] == '/a/b'

--- a/yamale/readers/yaml_reader.py
+++ b/yamale/readers/yaml_reader.py
@@ -1,17 +1,22 @@
 from __future__ import absolute_import
 
 
-def _pyyaml(file_name):
+def _pyyaml(file_name, constructors=None):
     import yaml
     try:
-        Loader = yaml.CSafeLoader
+        if constructors is not None:
+            Loader = yaml.Loader
+            for c in constructors:
+                yaml.add_constructor(c[0],c[1])
+        else:
+            Loader = yaml.CSafeLoader
     except AttributeError:  # System does not have libyaml
         Loader = yaml.SafeLoader
     with open(file_name) as f:
         return list(yaml.load_all(f, Loader=Loader))
 
 
-def _ruamel(file_name):
+def _ruamel(file_name, constructors=None):
     from ruamel.yaml import YAML
     yaml = YAML(typ='safe')
     with open(file_name) as f:
@@ -24,9 +29,9 @@ _parsers = {
 }
 
 
-def parse_file(file_name, parser):
+def parse_file(file_name, parser, constructors=None):
     try:
         parse = _parsers[parser.lower()]
     except KeyError:
         raise NameError('Parser "' + parser + '" is not supported\nAvailable parsers are listed below:\nPyYAML\nruamel')
-    return parse(file_name)
+    return parse(file_name, constructors)

--- a/yamale/tests/fixtures/custom_tags.yaml
+++ b/yamale/tests/fixtures/custom_tags.yaml
@@ -1,0 +1,2 @@
+source: &ROOT /a
+dest: !join [*ROOT, /b]

--- a/yamale/yamale.py
+++ b/yamale/yamale.py
@@ -28,9 +28,9 @@ def make_schema(path, parser='PyYAML', validators=None):
     return s
 
 
-def make_data(path, parser='PyYAML'):
+def make_data(path, parser='PyYAML', constructors=None):
     from . import readers
-    raw_data = readers.parse_file(path, parser)
+    raw_data = readers.parse_file(path, parser, constructors)
     return [Data(d, path) for d in raw_data]
 
 


### PR DESCRIPTION
This patch allows PyYAML constructors to be added so that data files may use custom tags.

This affects the interface for `yamale.make_data` but in a backwards compatible manner. There is the potential alternative to handle this with shared variables if that is preferable.

No support for ruamel as I am not familiar with it, but should be easy to add if the library supports custom constructors.