### PR TITLE
Fix #50 by changing the separator.

### DIFF
--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -67,7 +67,7 @@ class Schema(object):
         errors = []
 
         if position:
-            position = '%s.%s' % (position, key)
+            position = '%s%s%s' % (position, util.YAMALE_SEP, key)
         else:
             position = key
 

--- a/yamale/tests/fixtures/issue_50.yaml
+++ b/yamale/tests/fixtures/issue_50.yaml
@@ -1,0 +1,16 @@
+---
+ntp:
+  config:
+    enabled: bool()
+    ntp-source-address: str()
+  servers:
+    "192.168.1.1": include('ntp_servers')
+    "192.168.1.2": include('ntp_servers')
+---
+ntp_servers:
+  config: include('ntp_servers_config')
+ntp_servers_config:
+  port: int(min=123, max=123)
+  version: int(min=2, max=3)
+  prefer: bool()
+  address: str()

--- a/yamale/tests/fixtures/issue_50_good.yaml
+++ b/yamale/tests/fixtures/issue_50_good.yaml
@@ -1,0 +1,18 @@
+---
+ntp_server_profile_generic: &ntp_profile_generic
+  port: 123
+  version: 3
+  prefer: true
+ntp:
+  config:
+    enabled: true
+    ntp-source-address: 1.2.3.4
+  servers:
+    192.168.1.1:
+      config:
+        <<: *ntp_profile_generic
+        address: 192.168.1.1
+    192.168.1.2:
+      config:
+        <<: *ntp_profile_generic
+        address: 192.168.1.2

--- a/yamale/tests/test_functional.py
+++ b/yamale/tests/test_functional.py
@@ -1,7 +1,10 @@
 import pytest
 import yamale
+
 from . import get_fixture
 from .. import validators as val
+from yamale.util import YAMALE_SEP
+
 
 types = {
     'schema': 'types.yaml',
@@ -56,6 +59,11 @@ issue_22 = {
     'good': 'issue_22_good.yaml'
 }
 
+issue_50 = {
+    'schema': 'issue_50.yaml',
+    'good': 'issue_50_good.yaml'
+}
+
 regexes = {
     'schema': 'regex.yaml',
     'bad': 'regex_bad.yaml',
@@ -78,7 +86,7 @@ test_data = [
     types, nested, custom,
     keywords, lists, maps,
     anys, list_include, issue_22,
-    regexes, ips, macs
+    issue_50, regexes, ips, macs
 ]
 
 for d in test_data:
@@ -102,7 +110,7 @@ def test_nested_schema():
     nested_schema = nested['schema']
     assert isinstance(nested_schema['string'], val.String)
     assert isinstance(nested_schema.dict['list'], (list, tuple))
-    assert isinstance(nested_schema['list.0'], val.String)
+    assert isinstance(nested_schema['list%s0' % YAMALE_SEP], val.String)
 
 
 @pytest.mark.parametrize('data_map', test_data)

--- a/yamale/util.py
+++ b/yamale/util.py
@@ -9,6 +9,9 @@ except ImportError:
     from collections import Mapping, Set, Sequence
 
 
+YAMALE_SEP = '`/4M4|_E'
+
+
 # Python 3 has no basestring, lets test it.
 try:
     basestring  # attempt to evaluate basestring
@@ -37,10 +40,8 @@ def flatten(dic, keep_iter=False, position=None):
         return {}
 
     for k, v in get_iter(dic):
-        if isstr(k):
-            k = k.replace('.', '_')
         if position:
-            item_position = '%s.%s' % (position, k)
+            item_position = '%s%s%s' % (position, YAMALE_SEP, k)
         else:
             item_position = '%s' % k
 
@@ -58,7 +59,7 @@ def get_expanded_path(dic, key):
     path = []
     cur = dic
     try:
-        keys = key.split('.')
+        keys = key.split(YAMALE_SEP)
     except AttributeError:
         keys = [key]
     for k in keys[:-1]:


### PR DESCRIPTION
When flattening keys, the previous separator was a period. This caused
issues when the key itself had a period in it. We changed the separator
to a string that should never appear in the wild.