### PR TITLE
Fix error message output introduced in PR 58

### DIFF
--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -1,6 +1,8 @@
 import sys
+
 from .. import syntax, util
 from .. import validators as val
+from yamale.util import YAMALE_SEP
 
 # Fix Python 2.x.
 PY2 = sys.version_info[0] == 2
@@ -77,7 +79,7 @@ class Schema(object):
             if validator.is_optional:  # Optional? Who cares.
                 return errors
             # SHUT DOWN EVERTYHING
-            errors.append('%s: Required field missing' % position)
+            errors.append('%s: Required field missing' % position.replace(util.YAMALE_SEP, '.'))
             return errors
 
         return self._validate_item(validator, data_item, position, includes)
@@ -147,7 +149,8 @@ class Schema(object):
             return errors
 
         for key, validator in include_schema._schema.items():
-            errors += include_schema._validate(validator, data, includes=includes, key=key, position=pos)
+            errors += include_schema._validate(
+                validator, data, includes=includes, key=key, position=pos)
 
         return errors
 
@@ -175,6 +178,6 @@ class Schema(object):
         errors = validator.validate(data)
 
         for i, error in enumerate(errors):
-            errors[i] = '%s: ' % pos + error
+            errors[i] = '%s: ' % pos.replace(YAMALE_SEP, '.') + error
 
         return errors

--- a/yamale/tests/command_line_fixtures/required_keys_schema.yaml
+++ b/yamale/tests/command_line_fixtures/required_keys_schema.yaml
@@ -1,0 +1,2 @@
+map:
+  key: str()

--- a/yamale/tests/command_line_fixtures/yamls/required_keys_bad.yaml
+++ b/yamale/tests/command_line_fixtures/yamls/required_keys_bad.yaml
@@ -1,0 +1,2 @@
+map:
+  unknown_key: asdf

--- a/yamale/tests/test_command_line.py
+++ b/yamale/tests/test_command_line.py
@@ -10,13 +10,29 @@ parsers = ['pyyaml', 'PyYAML', 'ruamel']
 
 
 @pytest.mark.parametrize('parser', parsers)
-def test_bad_yaml(parser):
+def test_bad_yaml(capsys, parser):
     try:
         command_line._router(
             'yamale/tests/command_line_fixtures/yamls/bad.yaml',
             'schema.yaml', 1, parser)
     except ValueError as e:
         assert 'Validation failed!' in str(e)
+        captured = capsys.readouterr()
+        assert "map.bad: '12.5' is not a str." in captured.out
+        return
+    assert False
+
+
+@pytest.mark.parametrize('parser', parsers)
+def test_required_keys_yaml(capsys, parser):
+    try:
+        command_line._router(
+            'yamale/tests/command_line_fixtures/yamls/required_keys_bad.yaml',
+            'required_keys_schema.yaml', 1, parser)
+    except ValueError as e:
+        assert 'Validation failed!' in str(e)
+        captured = capsys.readouterr()
+        assert "map.key: Required field missing" in captured.out
         return
     assert False
 


### PR DESCRIPTION
Oops, the separator was used in the error message output, replacing it
with a dot.