### PR TITLE
HEL-356: add basic HTML tag validator

### DIFF
--- a/yamale/validators/tests/test_validate.py
+++ b/yamale/validators/tests/test_validate.py
@@ -142,3 +142,23 @@ def test_mac():
     assert not v.is_valid('ab:cd:ef:12:34:56:78')
     assert not v.is_valid('abcdefghijkl')
     assert not v.is_valid('1234567890ax')
+
+def test_html():
+    v = val.Html(tags=['strong', 'em'])
+    assert v.is_valid('<strong>Bold</strong>')
+    assert v.is_valid('<em>Daring</em>')
+    assert v.is_valid('<strong><em>Bold AND Daring</em></strong>')
+
+    assert not v.is_valid('<strong><em>Closes, wrong order</strong></em>')
+    assert not v.is_valid('<strong>Does not close')
+    assert not v.is_valid('<em>Does not close')
+
+    v = val.Html(tags=['br'])
+    assert not v.is_valid('hello<br>there')
+
+    v = val.Html(tags=['br'], self_closing=['br'])
+    assert v.is_valid('hello<br>there')
+
+    v = val.Html(tags=['ul', 'li', 'a'])
+    assert v.is_valid('<ul><li><a>Click me!</a></li></ul>')
+    assert not v.is_valid('<ul><li><a>Missing closing</li></ul>')


### PR DESCRIPTION
I'm going to guess I'm not the first person who's been using Yamale and tried to do this. 

The point is not to validate that all HTML is completely semantically valid, that all attributes are present, and so forth, but to allow the YAML schema author to whitelist HTML tags that are allowed in a simple string field, and to check that they open and close themselves correctly.