### PR TITLE
Make any() accept anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,12 +305,13 @@ Examples:
 
 
 ### Any - `any([validators])`
-Validates against a union of types. Use when a node can contain one of several types. It is valid if at least one of the listed validators is valid.
-- arguments: one or more validators to test values with
+Validates against a union of types. Use when a node can contain one of several types. It is valid if at least one of the listed validators is valid. If no validators are given, accept any value.
+- arguments: validators to test values with (if none is given, allow any value)
 
 Examples:
 - `any(int(), null())`: Validates an integer or a null value.
 - `any(num(), include('vector'))`: Validates a number or an included 'vector' type.
+- `any()`: Allows any value.
 
 ### Include - `include(include_name)`
 Validates included structures. Must supply the name of a valid include.

--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -178,8 +178,8 @@ class Schema(object):
 
     def _validate_any(self, validator, data, path, strict):
         if not validator.validators:
-            return
-        
+            return []
+
         errors = []
 
         sub_errors = []

--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -177,11 +177,10 @@ class Schema(object):
                                         strict)
 
     def _validate_any(self, validator, data, path, strict):
-        errors = []
-
         if not validator.validators:
-            errors.append('No validators specified for "any".')
-            return errors
+            return
+        
+        errors = []
 
         sub_errors = []
         for v in validator.validators:

--- a/yamale/tests/fixtures/any.yaml
+++ b/yamale/tests/fixtures/any.yaml
@@ -3,3 +3,4 @@ any_list: list(include('address'))
 address:
   street: str()
   postal_code: any(str(), int(), null())
+  note: any()

--- a/yamale/tests/fixtures/any_bad.yaml
+++ b/yamale/tests/fixtures/any_bad.yaml
@@ -1,7 +1,10 @@
 any_list:
   - street: "Pennsylvania"
     postal_code: 20500.0
+    note: 123
   - street: 100
     postal_code: "SW1A 2AA"
+    note: "Anything"
   - street: !!null
     postal_code: 0
+    note:

--- a/yamale/tests/fixtures/any_good.yaml
+++ b/yamale/tests/fixtures/any_good.yaml
@@ -1,7 +1,10 @@
 any_list:
   - street: "Pennsylvania"
     postal_code: 20500
+    note: 123
   - street: "Downing"
     postal_code: "SW1A 2AA"
+    note: "Anything"
   - street: "Fake"
     postal_code:
+    note:


### PR DESCRIPTION
Hi, this makes `any()` (without any arguments passed) to accept anything. This actually has the same effect by simply removing the key from the schema file. However, in my use case, I would like the users to see `key: any()` and knows that this key is optional rather than unavailable. Also, things get a bit different in strict mode, which would be helpful when one wants some key to present but does not care about its type. Thanks for reviewing!