### PR TITLE
Construct Result object for schema errors

### DIFF
--- a/yamale/schema/validationresults.py
+++ b/yamale/schema/validationresults.py
@@ -2,15 +2,28 @@ import sys
 
 PY2 = sys.version_info[0] == 2
 
-class ValidationResult:
 
-    def __init__(self, data, schema, errors):
-        self.data = data
-        self.schema = schema
+class Result(object):
+    def __init__(self, errors):
         self.errors = errors
 
     def __str__(self):
-        error_str = ""
+        error_str = '\n'.join(self.errors)
+        if PY2:
+            error_str = error_str.encode('utf-8')
+        return error_str
+
+    def isValid(self):
+        return len(self.errors) == 0
+
+
+class ValidationResult(Result):
+    def __init__(self, data, schema, errors):
+        super(ValidationResult, self).__init__(errors)
+        self.data = data
+        self.schema = schema
+
+    def __str__(self):
         if self.isValid():
             error_str = "'%s' is Valid" % self.data
         else: 
@@ -19,6 +32,3 @@ class ValidationResult:
         if PY2:
             error_str = error_str.encode('utf-8')
         return error_str
-
-    def isValid(self):
-        return len(self.errors) == 0

--- a/yamale/tests/test_command_line.py
+++ b/yamale/tests/test_command_line.py
@@ -68,6 +68,7 @@ def test_bad_dir():
             'yamale/tests/command_line_fixtures/yamls',
             'schema.yaml', 4, 'PyYAML')
 
+
 def test_bad_strict():
     with pytest.raises(ValueError) as e:
         command_line._router(


### PR DESCRIPTION
The schema errors were short-circuiting the rest of the yaml validation
when processing several directories. Wrapping them in a Result object
and passing it along as we do with yaml validation results lets all
these results be processed at the end.