### PR TITLE
Prevent int and num validators from accepting bool values.

### DIFF
--- a/yamale/tests/fixtures/numeric_bool_coercion.yaml
+++ b/yamale/tests/fixtures/numeric_bool_coercion.yaml
@@ -1,0 +1,2 @@
+integers: list(int())
+numbers: list(num())

--- a/yamale/tests/fixtures/numeric_bool_coercion_bad.yaml
+++ b/yamale/tests/fixtures/numeric_bool_coercion_bad.yaml
@@ -1,0 +1,6 @@
+integers:
+  - False
+  - True
+numbers:
+  - False
+  - True

--- a/yamale/tests/fixtures/numeric_bool_coercion_good.yaml
+++ b/yamale/tests/fixtures/numeric_bool_coercion_good.yaml
@@ -1,0 +1,6 @@
+integers:
+  - 0
+  - 1
+numbers:
+  - 0
+  - 1

--- a/yamale/tests/test_functional.py
+++ b/yamale/tests/test_functional.py
@@ -143,6 +143,12 @@ map_key_constraint = {
     'bad_nest_con': 'map_key_constraint_bad_nest_con.yaml',
 }
 
+numeric_bool_coercion = {
+    'schema': 'numeric_bool_coercion.yaml',
+    'good': 'numeric_bool_coercion_good.yaml',
+    'bad': 'numeric_bool_coercion_bad.yaml',
+}
+
 test_data = [
     types, nested, custom,
     keywords, lists, maps,
@@ -154,6 +160,7 @@ test_data = [
     nested_map2, static_list,
     nested_issue_54,
     map_key_constraint,
+    numeric_bool_coercion,
 ]
 
 for d in test_data:
@@ -321,6 +328,17 @@ def test_bad_map_key_constraint_nest_con():
                           map_key_constraint['bad_nest_con'],
                           exp)
 
+
+def test_bad_numeric_bool_coercion():
+    exp = [
+        "integers.0: 'False' is not a int.",
+        "integers.1: 'True' is not a int.",
+        "numbers.0: 'False' is not a num.",
+        "numbers.1: 'True' is not a num.",
+    ]
+    match_exception_lines(numeric_bool_coercion['schema'],
+                          numeric_bool_coercion['bad'],
+                          exp)
 
 @pytest.mark.parametrize("use_schema_string,use_data_string,expected_message_re", [
     (False, False, "^Error validating data '.*?' with schema '.*?'\n\t"),

--- a/yamale/validators/validators.py
+++ b/yamale/validators/validators.py
@@ -28,7 +28,7 @@ class Number(Validator):
     constraints = [con.Min, con.Max]
 
     def _is_valid(self, value):
-        return isinstance(value, (int, float))
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
 class Integer(Validator):
@@ -38,7 +38,7 @@ class Integer(Validator):
     constraints = [con.Min, con.Max]
 
     def _is_valid(self, value):
-        return isinstance(value, int)
+        return isinstance(value, int) and not isinstance(value, bool)
 
 
 class Boolean(Validator):


### PR DESCRIPTION
Adds a change to the Integer and Numeric validators such that they won't interpret boolean values (False, True) as valid, as well as tests outlining the expected behavior (and confirming that 0 and 1 are still accepted).

This is an issue caused by the origin of Bool in Python, as outlined in [PEP 285 -- Adding a bool type](https://www.python.org/dev/peps/pep-0285/):
> The bool type would be a straightforward subtype (in C) of the int type, and the values False and True would behave like 0 and 1 in most respects (for example, False==0 and True==1 would be true) except repr() and str().

For historical reasons, bool is a subtype of int in Python, but that is not the case in YAML (see e.g. https://yaml.org/type/bool.html). This can cause issues where Yamale validates a YAML document with a bool in an int-only field, and a downstream consumer (whether a non-Python program or a Python program using `str()` such as `jinja2`) ends in an invalid or unexpected state.

The behavior of the current `int` and `num` validators can be emulated by changing instances of `int()` and `num()` to `any(int(), bool())` and `any(num(), bool())`, so there is an easy upgrade path for users relying on this type coercion, if any.