### PR TITLE
Use python_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=['pyyaml'],
+    python_requires='>=3.6',
     entry_points={
         'console_scripts': ['yamale=yamale.command_line:main'],
     },


### PR DESCRIPTION
Current version of Yamale removed support for Python2, however trying to install it on Python2.7 results in an error. Using the python_requires keyword allows user of a specific python version to get the latest compatible package instead.

The error:
```
pip2 install yamale --user --upgrade
Collecting yamale
  Downloading https://files.pythonhosted.org/packages/1e/97/6734831a1316016ae16aa34a1875e77b9e8130f5b400c5bc96c24e56f79f/yamale-3.0.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-5_sFTr/yamale/setup.py", line 4, in <module>
        readme = open('README.md', encoding='utf-8').read()
    TypeError: 'encoding' is an invalid keyword argument for this function

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-5_sFTr/yamale/
```

Notes on how to use `python_requires`:
https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

To properly fix this, the 3.0.0 release should unfortunately be pulled down, and replaced by a 3.0.1 release which contains this fix.

Sorry to bother with a Python2 bug, but I hope this can be the last fix.