### PR TITLE
Add py.typed so that mypy knows that this package can be typed checked.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.md LICENSE
 include yamale/tests/fixtures/*.yaml
+include yamale/py.typed

--- a/yamale/py.typed
+++ b/yamale/py.typed
@@ -1,0 +1,1 @@
+"""File that lets mypy know that this module can be typed checked."""


### PR DESCRIPTION
This commit contians the py.typed file needed, to satisfy the PEP-561
requirement, so that type checkers know that Yamale can be type checked.