### PR TITLE
Added brew/python3/pip3 for Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Install
 $ pip install yamale
 ```
 
+*Mac OS users - try this:*
+```
+brew install python3
+pip3 install yamale
+```
+
 ### Manual
 1. Download Yamale from: https://github.com/23andMe/Yamale/archive/master.zip
 2. Unzip somewhere temporary


### PR DESCRIPTION
Installation on Mac OS is straightforward, if one has python3, which one can install via brew.