### PR TITLE
Add new base validator and base constraint classes

### DIFF
--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -52,7 +52,7 @@ class Schema(object):
 
     def validate(self, data, data_name, strict):
         path = DataPath()
-        errors = self._validate(self._schema, data, path, strict)
+        errors = self.validate_data(self._schema, data, path, strict)
         return ValidationResult(data_name, self.name, errors)
 
     def _validate_item(self, validator, data, path, strict, key):
@@ -73,9 +73,9 @@ class Schema(object):
             errors.append('%s: Required field missing' % path)
             return errors
 
-        return self._validate(validator, data_item, path, strict)
+        return self.validate_data(validator, data_item, path, strict)
 
-    def _validate(self, validator, data, path, strict):
+    def validate_data(self, validator, data, path, strict):
         """
         Validate data with validator.
         Special handling of non-primitive validators.
@@ -155,10 +155,10 @@ class Schema(object):
             return [('Include \'%s\' has not been defined.'
                      % validator.include_name)]
         strict = strict if validator.strict is None else validator.strict
-        return include_schema._validate(include_schema._schema,
-                                        data,
-                                        path,
-                                        strict)
+        return include_schema.validate_data(include_schema._schema,
+                                            data,
+                                            path,
+                                            strict)
 
     def _validate_any(self, validator, data, path, strict):
         if not validator.validators:
@@ -168,7 +168,7 @@ class Schema(object):
 
         sub_errors = []
         for v in validator.validators:
-            err = self._validate(v, data, path, strict)
+            err = self.validate_data(v, data, path, strict)
             if err:
                 sub_errors.append(err)
 

--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -89,14 +89,7 @@ class Schema(object):
                                                   path,
                                                   strict)
 
-        errors = []
-        # Optional field with optional value? Who cares.
-        if (data is None and
-                validator.is_optional and
-                validator.can_be_none):
-            return errors
-
-        errors += self._validate_primitive(validator, data, path)
+        errors = self._validate_primitive(validator, data, path, strict)
 
         if errors:
             return errors
@@ -186,10 +179,13 @@ class Schema(object):
 
         return errors
 
-    def _validate_primitive(self, validator, data, path):
-        errors = validator.validate(data)
+    def _validate_primitive(self, validator, data, path, strict):
+        errors = validator.validate(data, self, path, strict)
 
         for i, error in enumerate(errors):
-            errors[i] = ('%s: ' % path) + error
+            if str(path):
+                errors[i] = ('%s: ' % path) + error
+            else:
+                errors[i] = error
 
         return errors

--- a/yamale/tests/fixtures/map_key_constraint_include.yaml
+++ b/yamale/tests/fixtures/map_key_constraint_include.yaml
@@ -1,0 +1,4 @@
+maptest: map(include('value'), key=include('key'))
+---
+value: str()
+key: int()

--- a/yamale/tests/fixtures/map_key_constraint_include_bad.yaml
+++ b/yamale/tests/fixtures/map_key_constraint_include_bad.yaml
@@ -1,0 +1,3 @@
+maptest:
+  one: one
+  two: two

--- a/yamale/tests/fixtures/map_key_constraint_include_good.yaml
+++ b/yamale/tests/fixtures/map_key_constraint_include_good.yaml
@@ -1,0 +1,3 @@
+maptest:
+  1: one
+  2: two

--- a/yamale/tests/test_functional.py
+++ b/yamale/tests/test_functional.py
@@ -313,7 +313,7 @@ def test_bad_static_list():
 
 
 def test_bad_map_key_constraint_base():
-    exp = [": Key error - 'bad' is not a int."]
+    exp = ["Key error - 'bad' is not a int."]
     match_exception_lines(map_key_constraint['schema'],
                           map_key_constraint['bad_base'],
                           exp)

--- a/yamale/tests/test_functional.py
+++ b/yamale/tests/test_functional.py
@@ -149,6 +149,12 @@ numeric_bool_coercion = {
     'bad': 'numeric_bool_coercion_bad.yaml',
 }
 
+map_key_constraint_include = {
+    'schema': 'map_key_constraint_include.yaml',
+    'good': 'map_key_constraint_include_good.yaml',
+    'bad': 'map_key_constraint_include_bad.yaml'
+}
+
 test_data = [
     types, nested, custom,
     keywords, lists, maps,
@@ -161,6 +167,7 @@ test_data = [
     nested_issue_54,
     map_key_constraint,
     numeric_bool_coercion,
+    map_key_constraint_include
 ]
 
 for d in test_data:
@@ -338,6 +345,16 @@ def test_bad_numeric_bool_coercion():
     ]
     match_exception_lines(numeric_bool_coercion['schema'],
                           numeric_bool_coercion['bad'],
+                          exp)
+
+
+def test_bad_map_key_constraint_include():
+    exp = [
+        "maptest: Key error - 'one' is not a int.",
+        "maptest: Key error - 'two' is not a int."
+    ]
+    match_exception_lines(map_key_constraint_include['schema'],
+                          map_key_constraint_include['bad'],
                           exp)
 
 @pytest.mark.parametrize("use_schema_string,use_data_string,expected_message_re", [

--- a/yamale/validators/constraints.py
+++ b/yamale/validators/constraints.py
@@ -125,7 +125,7 @@ class Key(BaseConstraint):
 
     def _is_valid(self, value, schema, path, strict):
         for k in value.keys():
-            errors = schema._validate(self.key, k, DataPath(), strict)
+            errors = schema.validate_data(self.key, k, DataPath(), strict)
             if errors != []:
                 return False
         return True
@@ -133,7 +133,7 @@ class Key(BaseConstraint):
     def _fail(self, value, schema, path, strict):
         error_list = []
         for k in value.keys():
-            errors = schema._validate(self.key, k, DataPath(), strict)
+            errors = schema.validate_data(self.key, k, DataPath(), strict)
             error_list.extend(errors)
         return [self.fail % (e) for e in error_list]
 


### PR DESCRIPTION
Add new base classes to validator and constraint that take additional arguments, such as schema, path etc. This allows constraints to use non-primitive validators and resolves issue #133 

My initial intention was to pull out the logic for the non-primitive validators from the schema file and put them in each respective validator class but then I figured it would be a bit too drastic.. 