### PR TITLE
Add support for integers to Regex Validator

### DIFF
--- a/yamale/validators/validators.py
+++ b/yamale/validators/validators.py
@@ -164,7 +164,7 @@ class Regex(Validator):
         super(Regex, self).__init__(*args, **kwargs)
 
     def _is_valid(self, value):
-        return util.isstr(value) and any(r.match(value) for r in self.regexes)
+        return util.isstr(str(value)) and any(r.match(str(value)) for r in self.regexes)
 
     def get_name(self):
         return self.regex_name or self.tag + " match"


### PR DESCRIPTION
Currently, the Regex validator does not support integers despite the ability to easily cast integers to strings. In my use case, the test string could be a single VLAN, ex. 5, or a list of VLANs, ex. 1, 2, 3. While I could encapsulate the former example in quotes, my use case also requires a single VLAN to be an integer. This seems like a reasonable place to resolve the issue while creating additional functionality in lieu of creating a custom validator. 