### PR TITLE
[Feature] Adds Subset validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,19 @@ Examples:
 - `any(str(min=3, max=3),str(min=5, max=5),str(min=7, max=7))`: validates to a string that is exactly 3, 5, or 7 characters long
 - `any()`: Allows any value.
 
+### Subset - `subset([validators], allow_empty=False)`
+Validates against a subset of types. Unlike the `Any` validator, this validators allows **one or more** of several types.
+As such, it *automatically validates against a list*. It is valid if all values can be validated against at least one
+validator.
+- arguments: validators to test with (at least one; if none is given, a `ValueError` exception will be raised)
+- keywords:
+    - `allow_empty`: Allow the subset to be empty (and is, therefore, also optional). This overrides the `required`
+flag.
+      
+Examples:
+- `subset(int(), str())`: Validators against an integer, a string, or a list of either.
+- `subset(int(), str(), allow_empty=True)`: Same as above, but allows the empty set and makes the subset optional.
+
 ### Include - `include(include_name)`
 Validates included structures. Must supply the name of a valid include.
 - arguments: single name of a defined include, surrounded by quotes.

--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -110,8 +110,8 @@ class Schema(object):
         elif isinstance(validator, val.Any):
             errors += self._validate_any(validator, data, path, strict)
 
-        elif isinstance(validator, val.Union):
-            errors += self._validate_union(validator, data, path, strict)
+        elif isinstance(validator, val.Subset):
+            errors += self._validate_subset(validator, data, path, strict)
 
         return errors
 
@@ -189,7 +189,7 @@ class Schema(object):
 
         return errors
 
-    def _validate_union(self, validator, data, path, strict):
+    def _validate_subset(self, validator, data, path, strict):
         def _internal_validate(internal_data):
             sub_errors = []
             for val in validator.validators:

--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -205,16 +205,15 @@ class Schema(object):
             return []
 
         errors = []
-        if isinstance(data, dict):
+        if util.is_map(data):
             for k, v in data.items():
                 errors += _internal_validate({k: v})
-        elif isinstance(data, list):
+        elif util.is_list(data):
             for k in data:
                 errors += _internal_validate(k)
         else:
             errors += _internal_validate(data)
         return errors
-
 
     def _validate_primitive(self, validator, data, path):
         errors = validator.validate(data)

--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -110,6 +110,9 @@ class Schema(object):
         elif isinstance(validator, val.Any):
             errors += self._validate_any(validator, data, path, strict)
 
+        elif isinstance(validator, val.Union):
+            errors += self._validate_union(validator, data, path, strict)
+
         return errors
 
     def _validate_static_map_list(self, validator, data, path, strict):
@@ -185,6 +188,33 @@ class Schema(object):
                 errors += err
 
         return errors
+
+    def _validate_union(self, validator, data, path, strict):
+        def _internal_validate(internal_data):
+            sub_errors = []
+            for val in validator.validators:
+                err = self._validate(val, internal_data, path, strict)
+                if not err:
+                    break
+                sub_errors += err
+            else:
+                return sub_errors
+            return []
+
+        if not validator.validators:
+            return []
+
+        errors = []
+        if isinstance(data, dict):
+            for k, v in data.items():
+                errors += _internal_validate({k: v})
+        elif isinstance(data, list):
+            for k in data:
+                errors += _internal_validate(k)
+        else:
+            errors += _internal_validate(data)
+        return errors
+
 
     def _validate_primitive(self, validator, data, path):
         errors = validator.validate(data)

--- a/yamale/tests/fixtures/subset.yaml
+++ b/yamale/tests/fixtures/subset.yaml
@@ -1,0 +1,1 @@
+subset_list: subset(int(), str())

--- a/yamale/tests/fixtures/subset_bad.yaml
+++ b/yamale/tests/fixtures/subset_bad.yaml
@@ -1,0 +1,1 @@
+subset_list: !!null  # Empty subset not allowed

--- a/yamale/tests/fixtures/subset_bad2.yaml
+++ b/yamale/tests/fixtures/subset_bad2.yaml
@@ -1,0 +1,1 @@
+subset_list: [[1], "foo"]  # Wrong configuration

--- a/yamale/tests/fixtures/subset_bad3.yaml
+++ b/yamale/tests/fixtures/subset_bad3.yaml
@@ -1,0 +1,2 @@
+subset_list:
+  a: 1

--- a/yamale/tests/fixtures/subset_empty.yaml
+++ b/yamale/tests/fixtures/subset_empty.yaml
@@ -1,0 +1,1 @@
+subset_list: subset(int(), str(), allow_empty=True)

--- a/yamale/tests/fixtures/subset_empty_good.yaml
+++ b/yamale/tests/fixtures/subset_empty_good.yaml
@@ -1,0 +1,1 @@
+subset_list: !!null

--- a/yamale/tests/fixtures/subset_good.yaml
+++ b/yamale/tests/fixtures/subset_good.yaml
@@ -1,0 +1,1 @@
+subset_list: [1, "foo"]

--- a/yamale/tests/fixtures/subset_good2.yaml
+++ b/yamale/tests/fixtures/subset_good2.yaml
@@ -1,0 +1,1 @@
+subset_list: 1

--- a/yamale/tests/fixtures/subset_nodef.yaml
+++ b/yamale/tests/fixtures/subset_nodef.yaml
@@ -1,0 +1,1 @@
+foo: subset()

--- a/yamale/tests/test_functional.py
+++ b/yamale/tests/test_functional.py
@@ -163,6 +163,10 @@ subset_empty = {
     'good2': 'subset_empty_good2.yaml'
 }
 
+subset_nodef = {
+    'schema': 'subset_nodef.yaml'
+}
+
 test_data = [
     types, nested, custom,
     keywords, lists, maps,
@@ -175,8 +179,7 @@ test_data = [
     nested_issue_54,
     map_key_constraint,
     numeric_bool_coercion,
-    subset,
-    subset_empty
+    subset, subset_empty
 ]
 
 for d in test_data:
@@ -382,6 +385,12 @@ def test_bad_subset3():
     match_exception_lines(subset['schema'],
                           subset['bad3'],
                           exp)
+
+def test_nodef_subset_schema():
+    with pytest.raises(ValueError) as e:
+        yamale.make_schema(get_fixture(subset_nodef['schema']))
+
+    assert "'subset' requires at least one validator!" in str(e.value)
 
 @pytest.mark.parametrize("use_schema_string,use_data_string,expected_message_re", [
     (False, False, "^Error validating data '.*?' with schema '.*?'\n\t"),

--- a/yamale/tests/test_functional.py
+++ b/yamale/tests/test_functional.py
@@ -6,7 +6,6 @@ import yamale
 from . import get_fixture
 from .. import validators as val
 
-
 types = {
     'schema': 'types.yaml',
     'bad': 'types_bad_data.yaml',
@@ -149,6 +148,21 @@ numeric_bool_coercion = {
     'bad': 'numeric_bool_coercion_bad.yaml',
 }
 
+subset = {
+    'schema': 'subset.yaml',
+    'good': 'subset_good.yaml',
+    'good2': 'subset_good2.yaml',
+    'bad': 'subset_bad.yaml',
+    'bad2': 'subset_bad2.yaml',
+    'bad3': 'subset_bad3.yaml'
+}
+
+subset_empty = {
+    'schema': 'subset_empty.yaml',
+    'good': 'subset_empty_good.yaml',
+    'good2': 'subset_empty_good2.yaml'
+}
+
 test_data = [
     types, nested, custom,
     keywords, lists, maps,
@@ -161,6 +175,8 @@ test_data = [
     nested_issue_54,
     map_key_constraint,
     numeric_bool_coercion,
+    subset,
+    subset_empty
 ]
 
 for d in test_data:
@@ -189,7 +205,9 @@ def test_nested_schema():
 
 @pytest.mark.parametrize('data_map', test_data)
 def test_good(data_map):
-    yamale.validate(data_map['schema'], data_map['good'])
+    for k, v in data_map.items():
+        if k.startswith('good'):
+            yamale.validate(data_map['schema'], data_map[k])
 
 
 def test_bad_validate():
@@ -212,7 +230,6 @@ def test_bad_nested_issue_54():
         'list: Required field missing'
     ]
     match_exception_lines(nested_issue_54['schema'], nested_issue_54['bad'], exp)
-
 
 def test_bad_custom():
     assert count_exception_lines(custom['schema'], custom['bad']) == 1
@@ -338,6 +355,32 @@ def test_bad_numeric_bool_coercion():
     ]
     match_exception_lines(numeric_bool_coercion['schema'],
                           numeric_bool_coercion['bad'],
+                          exp)
+
+def test_bad_subset():
+    exp = [
+        "subset_list: 'subset' may not be an empty set."
+    ]
+    match_exception_lines(subset['schema'],
+                          subset['bad'],
+                          exp)
+
+def test_bad_subset2():
+    exp = [
+        "subset_list: '[1]' is not a int.",
+        "subset_list: '[1]' is not a str."
+    ]
+    match_exception_lines(subset['schema'],
+                          subset['bad2'],
+                          exp)
+
+def test_bad_subset3():
+    exp = [
+        "subset_list: '{'a': 1}' is not a int.",
+        "subset_list: '{'a': 1}' is not a str."
+    ]
+    match_exception_lines(subset['schema'],
+                          subset['bad3'],
                           exp)
 
 @pytest.mark.parametrize("use_schema_string,use_data_string,expected_message_re", [

--- a/yamale/validators/validators.py
+++ b/yamale/validators/validators.py
@@ -147,7 +147,11 @@ class Subset(Validator):
         self.validators = [val for val in args if isinstance(val, Validator)]
 
     def _is_valid(self, value):
-        return True
+        return self.can_be_none or value is not None
+
+    def fail(self, value):
+        # Called in case `_is_valid` returns False
+        return '\'%s\' may not be an empty set.' % self.get_name()
 
     @property
     def is_optional(self):

--- a/yamale/validators/validators.py
+++ b/yamale/validators/validators.py
@@ -145,6 +145,8 @@ class Subset(Validator):
         super(Subset, self).__init__(*args, **kwargs)
         self._allow_empty_set = bool(kwargs.pop('allow_empty', False))
         self.validators = [val for val in args if isinstance(val, Validator)]
+        if not self.validators:
+            raise ValueError('\'%s\' requires at least one validator!' % self.tag)
 
     def _is_valid(self, value):
         return self.can_be_none or value is not None

--- a/yamale/validators/validators.py
+++ b/yamale/validators/validators.py
@@ -143,10 +143,19 @@ class Subset(Validator):
 
     def __init__(self, *args, **kwargs):
         super(Subset, self).__init__(*args, **kwargs)
+        self._allow_empty_set = bool(kwargs.pop('allow_empty', False))
         self.validators = [val for val in args if isinstance(val, Validator)]
 
     def _is_valid(self, value):
         return True
+
+    @property
+    def is_optional(self):
+        return self._allow_empty_set
+
+    @property
+    def can_be_none(self):
+        return self._allow_empty_set
 
 
 class Null(Validator):

--- a/yamale/validators/validators.py
+++ b/yamale/validators/validators.py
@@ -137,12 +137,12 @@ class Any(Validator):
     def _is_valid(self, value):
         return True
 
-class Union(Validator):
-    """Union of several types validator"""
-    tag = 'union'
+class Subset(Validator):
+    """Subset of several types validator"""
+    tag = 'subset'
 
     def __init__(self, *args, **kwargs):
-        super(Union, self).__init__(*args, **kwargs)
+        super(Subset, self).__init__(*args, **kwargs)
         self.validators = [val for val in args if isinstance(val, Validator)]
 
     def _is_valid(self, value):

--- a/yamale/validators/validators.py
+++ b/yamale/validators/validators.py
@@ -137,6 +137,17 @@ class Any(Validator):
     def _is_valid(self, value):
         return True
 
+class Union(Validator):
+    """Union of several types validator"""
+    tag = 'union'
+
+    def __init__(self, *args, **kwargs):
+        super(Union, self).__init__(*args, **kwargs)
+        self.validators = [val for val in args if isinstance(val, Validator)]
+
+    def _is_valid(self, value):
+        return True
+
 
 class Null(Validator):
     """Validates null"""


### PR DESCRIPTION
Similiar to the `any` validator, except it allows combining multiple types (instead of exactly one).
This is mostly useful for various `Include`s, thereby allowing some sort of conditional key-value pairs, such as the following. Granted this example is over-simplistic and can be resolved in other ways (such as explicitly specifying the mapping values), but this would apply to a recursive definition as well.
```yaml
# schema.yaml
my_types: union(include('type1'), include('type2'))
---
type1: map(str(), key=regex('^my_str(ing)?$', ignore_case=True))
---
type2: map(int(), key=regex('^my_int(eger)?$', ignore_case=True))

# data_success.yaml
my_types:
  my_string: foo
  my_int: 3

# data_fail.yaml
my_types:
  my_string: 3  # Not a string
  my_int: foo  # Not an int
```