### PR TITLE
Limit the strings which can be eval'd

### DIFF
--- a/yamale/syntax/parser.py
+++ b/yamale/syntax/parser.py
@@ -8,6 +8,16 @@ safe_builtins = dict((f, __builtins__[f]) for f in safe_globals)
 
 def parse(validator_string, validators=None):
     validators = validators or val.DefaultValidators
+
+    if validator_string:
+        for validator in validators.keys():
+            if validator_string.startswith(validator):
+                break
+        else:
+            raise SyntaxError(
+                'Invalid schema expression: \'%s\'. ' % validator_string
+            )
+
     try:
         tree = ast.parse(validator_string, mode='eval')
         # evaluate with access to a limited global scope only


### PR DESCRIPTION
When processing the schema, each line is run through Python's eval
function to make the validator available. A well constructed string
within the schema rules can execute system commands. This change limits
the string to those that begin with the known validators.