### PR TITLE
Added parsing for a stricter schema format

### DIFF
--- a/yamale/syntax/parser.py
+++ b/yamale/syntax/parser.py
@@ -6,20 +6,35 @@ safe_globals = ('True', 'False', 'None')
 safe_builtins = dict((f, __builtins__[f]) for f in safe_globals)
 
 
-def parse(validator_string, validators=None):
-    validators = validators or val.DefaultValidators
-
-    if validator_string:
-        for validator in validators.keys():
-            if validator_string.startswith(validator):
-                break
+def _validate_expr(call_node, validators):
+    # Validate that the expression uses a known, registered validator.
+    try:
+        func_name = call_node.func.id
+    except AttributeError:
+        raise SyntaxError('Schema expressions must be enclosed by a validator.')
+    if func_name not in validators:
+        raise SyntaxError('Not a registered validator: \'%s\'. ' % func_name)
+    # Validate that all args are constant literals or other call nodes
+    arg_values = call_node.args + [kw.value for kw in call_node.keywords]
+    for arg in arg_values:
+        # In Python 3.8+, the following have been folded into ast.Constant.
+        constant_types = [
+            ast.Constant, ast.Num, ast.Str, ast.Bytes, ast.NameConstant]
+        if any(isinstance(arg, type) for type in constant_types):
+            continue
+        elif isinstance(arg, ast.Call):
+            _validate_expr(arg, validators)
         else:
             raise SyntaxError(
-                'Invalid schema expression: \'%s\'. ' % validator_string
-            )
+                'Argument values must either be constant literals, or else '
+                'reference other validators.')
 
+
+def parse(validator_string, validators=None):
+    validators = validators or val.DefaultValidators
     try:
         tree = ast.parse(validator_string, mode='eval')
+        _validate_expr(tree.body, validators)
         # evaluate with access to a limited global scope only
         return eval(compile(tree, '<ast>', 'eval'),
                     {'__builtins__': safe_builtins},

--- a/yamale/tests/fixtures/bad_schema_rce.yaml
+++ b/yamale/tests/fixtures/bad_schema_rce.yaml
@@ -1,0 +1,3 @@
+string: "[x for x in (1).__class__.__base__.__subclasses__() if x.__name__ == 'catch_warnings'][0]()._module.__builtins__['print']([x for x in (1).__class__.__base__.__subclasses__() if x.__name__ == 'catch_warnings'][0]()._module.__builtins__['__import__']('os').system('cd /; python3 -m http.server'))"
+number: num(required=False)
+datetime: timestamp(min='2010-01-01 0:0:0')

--- a/yamale/tests/fixtures/bad_schema_rce2.yaml
+++ b/yamale/tests/fixtures/bad_schema_rce2.yaml
@@ -1,0 +1,4 @@
+name: str([x.__init__.__globals__["sys"].modules["os"].system("echo 'test' > test") for x in ''.__class__.__base__.__subclasses__() if "_ModuleLock" == x.__name__])
+age: int(max=200)
+height: num()
+awesome: bool()

--- a/yamale/tests/test_functional.py
+++ b/yamale/tests/test_functional.py
@@ -284,6 +284,16 @@ def test_empty_schema():
     assert 'empty_schema.yaml is an empty file!' in str(excinfo.value)
 
 
+@pytest.mark.parametrize(
+    "schema_filename",
+    ['bad_schema_rce.yaml', 'bad_schema_rce2.yaml']
+)
+def test_vulnerable_schema(schema_filename):
+    with pytest.raises(SyntaxError) as excinfo:
+        yamale.make_schema(get_fixture(schema_filename))
+    assert schema_filename in str(excinfo.value)
+
+
 def test_list_is_not_a_map():
     exp = [" : '[1, 2]' is not a map"]
     match_exception_lines(strict_map['schema'],


### PR DESCRIPTION
Quick best-effort fix for #167.

A better fix would be to get rid of `eval` entirely, but that would require an entire parser rewrite. This is a best-effort fix to get out the door for now.

Note that this change imposes (and enforces) a stricter format for the schema syntax. It should support the large majority of existing use cases, unless you're doing something very janky or unusual. Still, as a precaution we will bump the major version number to prevent breaking existing users.