### PR TITLE
Fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ try:
     print('Validation success! 👍')
 except YamaleError as e:
     print('Validation failed!\n')
-    for result in e.value.results:
+    for result in e.results:
         print("Error validating data '%s' with '%s'\n\t" % (result.data, result.schema))
         for error in result.errors:
             print('\t%s' % error)


### PR DESCRIPTION
Validation results are currently in `YamaleError.results` instead of `YamaleError.value.results` - https://github.com/23andMe/Yamale/blob/master/yamale/yamale_error.py#L5 .