### PR TITLE
Check for UnicodeEncodeError when printing the success message

### DIFF
--- a/yamale/command_line.py
+++ b/yamale/command_line.py
@@ -120,10 +120,13 @@ def main():
     args = parser.parse_args()
     try:
         _router(args.path, args.schema, args.cpu_num, args.parser, not args.no_strict)
-        print('Validation success! 👍')
     except (SyntaxError, NameError, TypeError, ValueError) as e:
         print('Validation failed!\n%s' % str(e))
         exit(1)
+    try:
+        print('Validation success! 👍')
+    except UnicodeEncodeError:
+        print('Validation success!')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi,

Thanks for your great work!

There exists an issue I've encountered in several environments with printing "👍".
The problem is that we get "Validation failed!" trying to print "Validation success! 👍" which is both funny and incorrect.

The issue can be reproduced in ubuntu docker, but it is not limited to docker in my experience.

I prefer to keep the original message when possible, which dictates the `try ... except` approach in the PR.