### PR TITLE
Support relative schema path

### DIFF
--- a/yamale/command_line.py
+++ b/yamale/command_line.py
@@ -51,6 +51,8 @@ def _find_schema(data_path, schema_name):
     """ Checks if `schema_name` is a valid file, if not
     searches in `data_path` for it. """
 
+    if os.path.isfile(schema_name):
+        return schema_name
     directory = os.path.dirname(data_path)
     path = glob.glob(os.path.join(directory, schema_name))
     for p in path:


### PR DESCRIPTION
This PR is adding a check if the specified schema is actually a path to an existing file. Without this change, the schema cannot be find if the data path and the schema path combination doesn't produce an existing path to the schema. To demonstrate this, let's have this directory structure:

```
/dir1/data/myfile.yaml
/dir2/schemas/myfile.yaml
```

If we are in the `/dir2` and we run Yamale, the schema is not found:

```shell
cd /dir2
yamale -s ./schemas/myfile.yaml /dir1/data/myfile.yaml
```