### PR TITLE
Use utf-8 as default yaml file encoding

### DIFF
--- a/yamale/readers/yaml_reader.py
+++ b/yamale/readers/yaml_reader.py
@@ -31,7 +31,7 @@ def parse_yaml(path=None, parser='pyyaml', content=None):
     if (path is None and content is None) or (path is not None and content is not None):
         raise TypeError("Pass either path= or content=, not both")
     if path is not None:
-        with open(path) as f:
+        with open(path, encoding='utf8') as f:
             return parse(f)
     else:
         return parse(StringIO(content))


### PR DESCRIPTION
I'm using windows with cp1251 as default encoding and if i trying to read file with non ascii characters pyyaml crashes, but solution is very simple