### PR TITLE
avoid appending undefined path

### DIFF
--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -219,6 +219,9 @@ class Schema(object):
         errors = validator.validate(data)
 
         for i, error in enumerate(errors):
-            errors[i] = ('%s: ' % path) + error
+            if path:
+                errors[i] = ('%s: ' % path) + error
+            else:
+                errors[i] = error
 
         return errors


### PR DESCRIPTION
When the path is undefined, we get an error msg starting with colon:
```shell
`: my error msg`
```