### PR TITLE
fix 3.12 deprecations

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: [3.8, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ to the syntax [here](https://github.com/Animosity/CraftIRC/wiki/Complete-idiot's
 
 Requirements
 ------------
-* Python 3.6+
+* Python 3.8+
 * PyYAML
 * ruamel.yaml (optional)
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=['pyyaml'],
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     entry_points={
         'console_scripts': ['yamale=yamale.command_line:main'],
     },
@@ -29,9 +29,10 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py36,py38
+envlist = py38, py310
 
 [gh-actions]
 python =
-    3.6: py36
     3.8: py38
+    3.10: py310
 
 [testenv]
 commands = py.test --cov yamale --cov-report term-missing yamale

--- a/yamale/syntax/parser.py
+++ b/yamale/syntax/parser.py
@@ -17,11 +17,8 @@ def _validate_expr(call_node, validators):
     # Validate that all args are constant literals, validator names,  or other call nodes
     arg_values = call_node.args + [kw.value for kw in call_node.keywords]
     for arg in arg_values:
-        # In Python 3.8+, the following have been folded into ast.Constant.
-        constant_types = [
-            ast.Constant, ast.Num, ast.Str, ast.Bytes, ast.NameConstant]
         base_arg = arg.operand if isinstance(arg, ast.UnaryOp) else arg
-        if any(isinstance(base_arg, type) for type in constant_types):
+        if isinstance(base_arg, ast.Constant):
             continue
         elif isinstance(base_arg, ast.Name) and base_arg.id in validators:
             continue


### PR DESCRIPTION
closes #234 

Note that this change is incompatible with Python `<3.8`, therefore I raised the `python_requires` lower bound accordingly