### PR TITLE
fix(cli): check schema to be a valid path first

### DIFF
--- a/yamale/command_line.py
+++ b/yamale/command_line.py
@@ -52,6 +52,9 @@ def _find_schema(data_path, schema_name):
     """ Checks if `schema_name` is a valid file, if not
     searches in `data_path` for it. """
 
+    if os.path.isfile(schema_name):
+        return schema_name
+
     directory = os.path.dirname(data_path)
     path = glob.glob(os.path.join(directory, schema_name))
     for p in path:

--- a/yamale/tests/test_command_line.py
+++ b/yamale/tests/test_command_line.py
@@ -1,4 +1,5 @@
 import os
+import contextlib
 
 import pytest
 
@@ -8,6 +9,14 @@ from .. import yamale_error
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
 parsers = ['pyyaml', 'PyYAML', 'ruamel']
+
+
+@contextlib.contextmanager
+def scoped_chandge_dir(new_dir):
+    cwd = os.getcwd()
+    os.chdir(new_dir)
+    try: yield
+    finally: os.chdir(cwd)
 
 
 @pytest.mark.parametrize('parser', parsers)
@@ -33,21 +42,29 @@ def test_good_yaml(parser):
     command_line._router(
         'yamale/tests/command_line_fixtures/yamls/good.yaml',
         'schema.yaml', 1, parser)
-    
+
 
 @pytest.mark.parametrize('parser', parsers)
 def test_good_relative_yaml(parser):
     command_line._router(
         'yamale/tests/command_line_fixtures/yamls/good.yaml',
         '../schema_dir/external.yaml', 1, parser)
-    
+
+
+@pytest.mark.parametrize('parser', parsers)
+def test_good_relative_schema_in_subfolder(parser):
+    with scoped_chandge_dir('yamale/tests/command_line_fixtures/schema_dir'):
+        command_line._router(
+            '../yamls/good.yaml',
+            'external.yaml', 1, parser)
+
 
 @pytest.mark.parametrize('parser', parsers)
 def test_external_glob_schema(parser):
     command_line._router(
         'yamale/tests/command_line_fixtures/yamls/good.yaml',
         os.path.join(dir_path, 'command_line_fixtures/schema_dir/ex*.yaml'), 1, parser)
-    
+
 
 def test_empty_schema_file():
     with pytest.raises(ValueError, match='is an empty file!'):


### PR DESCRIPTION
Check that `schema_name` is a valid file before iterating over parent directories of `data_path` (the change is taken from [quite old PR](https://github.com/23andMe/Yamale/pull/192)).
Fix for https://github.com/23andMe/Yamale/issues/238 .

## Details
It is a breaking change in terms of behaviour (as [pointed out in the old PR](https://github.com/23andMe/Yamale/pull/192#issuecomment-1041892826)), because invocations like `yamale a/b/c.yaml --schema=x/y/z/schema.yaml` will now _first_ check `$PWD/x/y/z.yaml` file for being a schema _instead of_ starting from `$PWD/a/b/x/y/z/schema.yaml` and iterating over parents (`$PWD/a/x/y/z/schema`, `$PWD/x/y/z/schema`, etc). This changes the order in which schema files are used.
But, to be honest, I don't think this will cause many troubles, because the "fixed" behaviour corresponds to linux-way of referencing files, while the "old" behaviour was a bit counter-intuitive.

It is possible to implement a fix without changing the behaviour - basically check `schema_name` for being a file _after_ all other attempts fail, but that will require a bit more changes and may complicate the code. I can implement it if you insist.

## PR structure
There are 2 commits:
- the first adds a test for the [described scenario](https://github.com/23andMe/Yamale/issues/238) (and fails without the fix);
- the second commit implements the fix;