### PR TITLE
(fix)semver: SyntaxWarning: invalid escape sequence

### DIFF
--- a/yamale/validators/validators.py
+++ b/yamale/validators/validators.py
@@ -243,8 +243,8 @@ class Mac(Regex):
     def __init__(self, *args, **kwargs):
         super(Mac, self).__init__(*args, **kwargs)
         self.regexes = [
-            re.compile("[0-9a-fA-F]{2}([-:]?)[0-9a-fA-F]{2}(\\1[0-9a-fA-F]{2}){4}$"),
-            re.compile("[0-9a-fA-F]{4}([-:]?)[0-9a-fA-F]{4}(\\1[0-9a-fA-F]{4})$"),
+            re.compile(r"[0-9a-fA-F]{2}([-:]?)[0-9a-fA-F]{2}(\\1[0-9a-fA-F]{2}){4}$"),
+            re.compile(r"[0-9a-fA-F]{4}([-:]?)[0-9a-fA-F]{4}(\\1[0-9a-fA-F]{4})$"),
         ]
 
 
@@ -257,7 +257,7 @@ class SemVer(Regex):
         super(SemVer, self).__init__(*args, **kwargs)
         self.regexes = [
             # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-            re.compile("^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"),
+            re.compile(r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"),
         ]
 
 

--- a/yamale/validators/validators.py
+++ b/yamale/validators/validators.py
@@ -243,8 +243,8 @@ class Mac(Regex):
     def __init__(self, *args, **kwargs):
         super(Mac, self).__init__(*args, **kwargs)
         self.regexes = [
-            re.compile(r"[0-9a-fA-F]{2}([-:]?)[0-9a-fA-F]{2}(\\1[0-9a-fA-F]{2}){4}$"),
-            re.compile(r"[0-9a-fA-F]{4}([-:]?)[0-9a-fA-F]{4}(\\1[0-9a-fA-F]{4})$"),
+            re.compile(r"[0-9a-fA-F]{2}([-:]?)[0-9a-fA-F]{2}(\1[0-9a-fA-F]{2}){4}$"),
+            re.compile(r"[0-9a-fA-F]{4}([-:]?)[0-9a-fA-F]{4}(\1[0-9a-fA-F]{4})$"),
         ]
 
 


### PR DESCRIPTION
Fix SyntaxWarning:

```python
.../yamale/validators/validators.py:260: SyntaxWarning: invalid escape sequence '\d'
  re.compile("^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"),
```

To reproduce this error, you need to run Python with `-W error` or `export PYTHONWARNING=error`.

Error was there for semver only but I fixed typo for `mac()` as well