### PR TITLE
Add ruamel dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,10 @@ setup(
     license="MIT",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["pyyaml"],
+    install_requires=[
+        "pyyaml",
+        "ruamel.yaml",
+    ],
     python_requires=">=3.8",
     entry_points={
         "console_scripts": ["yamale=yamale.command_line:main"],


### PR DESCRIPTION
project is missing the `ruamel.yaml` dependency. I had to install it manually after a failed runtime exception.