### PR TITLE
Feature: keyed 'subset' and 'any' validators

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,10 +17,10 @@ jobs:
         python-version: ["3.8", "3.12"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: chartboost/ruff-action@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -406,11 +406,14 @@ Validates [Semantic Versioning](https://semver.org/) strings.
 Examples:
 - `semver()`: Allows any valid SemVer string
 
-### Any - `any([validators])`
+### Any - `any([validators], key='field_name')`
 Validates against a union of types. Use when a node **must** contain **one and only one** of several types. It is valid
 if at least one of the listed validators is valid. If no validators are given, accept any value.
 - arguments: validators to test values with (if none is given, allow any value; if one or more are given,
 one must be present)
+
+- keywords:
+    - `key`: Used to limit the validation of includes, the any validator will check if the specified field matches whats specified by each include validator before running the validator. 
 
 Examples:
 - `any(int(), null())`: Validates either an integer **or** a null value.
@@ -418,13 +421,14 @@ Examples:
 - `any(str(min=3, max=3),str(min=5, max=5),str(min=7, max=7))`: validates to a string that is exactly 3, 5, or 7 characters long
 - `any()`: Allows any value.
 
-### Subset - `subset([validators], allow_empty=False)`
+### Subset - `subset([validators], allow_empty=False, key='field_name')`
 Validates against a subset of types. Unlike the `Any` validator, this validators allows **one or more** of several types.
 As such, it *automatically validates against a list*. It is valid if all values can be validated against at least one
 validator.
 - arguments: validators to test with (at least one; if none is given, a `ValueError` exception will be raised)
 - keywords:
     - `allow_empty`: Allow the subset to be empty (and is, therefore, also optional). This overrides the `required`
+    - `key`: Limits the validation of includes, the subset validator will check if the specified field matches whats specified by each include validator before running the validator. 
 flag.
 
 Examples:

--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -212,12 +212,15 @@ class Schema(object):
         field_value = internal_data[validator.key]
         result = []
         for v in validator.validators:
-            if not isinstance(v, val.Include): continue
+            if not isinstance(v, val.Include):
+                continue
 
             sub_validator = self.includes.get(v.include_name)
             sub_schema = sub_validator.dict
 
-            if validator.key not in sub_schema: continue
+            if validator.key not in sub_schema:
+                continue
+            
             field_validator = sub_schema[validator.key]
             if field_validator._is_valid(field_value):
                 result.append(v)

--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -164,13 +164,14 @@ class Schema(object):
 
         errors = []
 
+        validators = self._get_include_validators_for_key(validator, data)
         sub_errors = []
-        for v in validator.validators:
+        for v in validators:
             err = self._validate(v, data, path, strict)
             if err:
                 sub_errors.append(err)
 
-        if len(sub_errors) == len(validator.validators):
+        if len(sub_errors) == len(validators):
             # All validators failed, add to errors
             for err in sub_errors:
                 errors += err

--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -203,6 +203,25 @@ class Schema(object):
             errors += _internal_validate(data)
         return errors
 
+    def _get_include_validators_for_key(self, validator, internal_data):
+        if len(validator.key) == 0: 
+            return validator.validators
+        
+        field_value = internal_data[validator.key]
+        result = []
+        for v in validator.validators:
+            if not isinstance(v, val.Include): continue
+
+            sub_validator = self.includes.get(v.include_name)
+            sub_schema = sub_validator.dict
+
+            if validator.key not in sub_schema: continue
+            field_validator = sub_schema[validator.key]
+            if field_validator._is_valid(field_value):
+                result.append(v)
+        
+        return result
+
     def _validate_primitive(self, validator, data, path):
         errors = validator.validate(data)
 

--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -179,8 +179,9 @@ class Schema(object):
 
     def _validate_subset(self, validator, data, path, strict):
         def _internal_validate(internal_data):
+            validators = self._get_include_validators_for_key(validator, internal_data)
             sub_errors = []
-            for v in validator.validators:
+            for v in validators:
                 err = self._validate(v, internal_data, path, strict)
                 if not err:
                     break

--- a/yamale/schema/schema.py
+++ b/yamale/schema/schema.py
@@ -206,7 +206,7 @@ class Schema(object):
         return errors
 
     def _get_include_validators_for_key(self, validator, internal_data):
-        if len(validator.key) == 0: 
+        if len(validator.key) == 0 or validator.key not in internal_data: 
             return validator.validators
         
         field_value = internal_data[validator.key]

--- a/yamale/syntax/parser.py
+++ b/yamale/syntax/parser.py
@@ -14,7 +14,7 @@ def _validate_expr(call_node, validators):
         raise SyntaxError("Schema expressions must be enclosed by a validator.")
     if func_name not in validators:
         raise SyntaxError("Not a registered validator: '%s'. " % func_name)
-    # Validate that all args are constant literals, validator names,  or other call nodes
+    # Validate that all args are constant literals, validator names, or other call nodes
     arg_values = call_node.args + [kw.value for kw in call_node.keywords]
     for arg in arg_values:
         base_arg = arg.operand if isinstance(arg, ast.UnaryOp) else arg

--- a/yamale/tests/keyed_fixtures/data_keyed_any_with_include_bad.yaml
+++ b/yamale/tests/keyed_fixtures/data_keyed_any_with_include_bad.yaml
@@ -1,0 +1,3 @@
+deploy:
+  strategy: branch
+  branch: [dev]

--- a/yamale/tests/keyed_fixtures/data_keyed_any_with_include_good.yaml
+++ b/yamale/tests/keyed_fixtures/data_keyed_any_with_include_good.yaml
@@ -1,0 +1,3 @@
+deploy:
+  strategy: preview
+  branch: [dev]

--- a/yamale/tests/keyed_fixtures/data_keyed_subset_with_include_bad.yaml
+++ b/yamale/tests/keyed_fixtures/data_keyed_subset_with_include_bad.yaml
@@ -1,0 +1,5 @@
+workloads:
+  - type: api
+    name: test
+    file: test.docker
+    replicas: 14

--- a/yamale/tests/keyed_fixtures/data_keyed_subset_with_include_good.yaml
+++ b/yamale/tests/keyed_fixtures/data_keyed_subset_with_include_good.yaml
@@ -1,0 +1,5 @@
+workloads:
+  - type: ui
+    name: test
+    file: test.docker
+    replicas: 14

--- a/yamale/tests/keyed_fixtures/schema_keyed_any_with_include.yaml
+++ b/yamale/tests/keyed_fixtures/schema_keyed_any_with_include.yaml
@@ -1,0 +1,8 @@
+deploy: any(include('deploy-max'), include('deploy-branch'), required=False, key='strategy')
+---
+deploy-max:
+  strategy: enum('preview')
+  branch: list(enum('dev', 'tst', 'uat'))
+---
+deploy-branch:
+  strategy: enum('branch')

--- a/yamale/tests/keyed_fixtures/schema_keyed_subset_with_include.yaml
+++ b/yamale/tests/keyed_fixtures/schema_keyed_subset_with_include.yaml
@@ -1,0 +1,12 @@
+workloads: subset(include('ui_service'), include('api_service'), key='type')
+---
+ui_service:
+  type: enum('ui')
+  name: str()
+  file: str()
+  replicas: num(required=False)
+---
+api_service:
+  type: enum('api')
+  name: str()
+  file: str()

--- a/yamale/tests/test_keyed_fixtures.py
+++ b/yamale/tests/test_keyed_fixtures.py
@@ -1,4 +1,5 @@
-import os, pytest
+import os
+import pytest
 from yamale import YamaleError
 import yamale.yamale_testcase as tc
 
@@ -26,7 +27,7 @@ def test_keyed_subset_with_include_should_succeed():
     yaml = "keyed_fixtures/data_keyed_subset_with_include_good.yaml"
 
     result = tc.run_validate(schema, yaml, base_dir)
-    assert result == True
+    assert result
 
 
 def test_keyed_any_with_include_should_fail_with_correct_message():
@@ -48,4 +49,4 @@ def test_keyed_any_with_include_should_succeed():
     schema = "keyed_fixtures/schema_keyed_any_with_include.yaml"
     yaml = "keyed_fixtures/data_keyed_any_with_include_good.yaml"
     result = tc.run_validate(schema, yaml, base_dir)
-    assert result == True
+    assert result

--- a/yamale/tests/test_keyed_fixtures.py
+++ b/yamale/tests/test_keyed_fixtures.py
@@ -1,0 +1,51 @@
+import os, pytest
+from yamale import YamaleError
+import yamale.yamale_testcase as tc
+
+data_folder = os.path.dirname(os.path.realpath(__file__))
+
+
+def test_keyed_subset_with_include_should_fail_with_correct_message():
+    base_dir = data_folder
+    schema = "keyed_fixtures/schema_keyed_subset_with_include.yaml"
+    yaml = "keyed_fixtures/data_keyed_subset_with_include_bad.yaml"
+    valid_msg = "workloads.replicas: Unexpected element"
+    invalid_msg = "workloads.type: 'api' not in ('ui',)"
+    
+    
+    with pytest.raises(YamaleError) as excinfo:
+        tc.run_validate(schema, yaml, base_dir)
+   
+    assert valid_msg in str(excinfo.value)
+    assert invalid_msg not in str(excinfo.value)
+
+
+def test_keyed_subset_with_include_should_succeed():
+    base_dir = data_folder
+    schema = "keyed_fixtures/schema_keyed_subset_with_include.yaml"
+    yaml = "keyed_fixtures/data_keyed_subset_with_include_good.yaml"
+
+    result = tc.run_validate(schema, yaml, base_dir)
+    assert result == True
+
+
+def test_keyed_any_with_include_should_fail_with_correct_message():
+    base_dir = data_folder
+    schema = "keyed_fixtures/schema_keyed_any_with_include.yaml"
+    yaml = "keyed_fixtures/data_keyed_any_with_include_bad.yaml"
+    valid_msg = "deploy.branch: Unexpected element"
+    invalid_msg = "deploy.strategy: 'branch' not in ('preview',)"
+
+    with pytest.raises(YamaleError) as excinfo:
+        tc.run_validate(schema, yaml, base_dir)
+    
+    assert valid_msg in str(excinfo.value)
+    assert invalid_msg not in str(excinfo.value)
+
+
+def test_keyed_any_with_include_should_succeed():
+    base_dir = data_folder
+    schema = "keyed_fixtures/schema_keyed_any_with_include.yaml"
+    yaml = "keyed_fixtures/data_keyed_any_with_include_good.yaml"
+    result = tc.run_validate(schema, yaml, base_dir)
+    assert result == True

--- a/yamale/validators/validators.py
+++ b/yamale/validators/validators.py
@@ -150,6 +150,7 @@ class Any(Validator):
     tag = "any"
 
     def __init__(self, *args, **kwargs):
+        self.key = str(kwargs.pop("key", ''))
         self.validators = [val for val in args if isinstance(val, Validator)]
         super(Any, self).__init__(*args, **kwargs)
 
@@ -165,6 +166,7 @@ class Subset(Validator):
     def __init__(self, *args, **kwargs):
         super(Subset, self).__init__(*args, **kwargs)
         self._allow_empty_set = bool(kwargs.pop("allow_empty", False))
+        self.key = str(kwargs.pop("key", ''))
         self.validators = [val for val in args if isinstance(val, Validator)]
         if not self.validators:
             raise ValueError("'%s' requires at least one validator!" % self.tag)

--- a/yamale/yamale_testcase.py
+++ b/yamale/yamale_testcase.py
@@ -17,32 +17,33 @@ class YamaleTestCase(TestCase):
     schema = None
     yaml = None
     base_dir = None
+    errors = []
 
     def validate(self, validators=None):
-        schema = self.schema
-        yaml = self.yaml
-        base_dir = self.base_dir
+        return run_validate(self.schema, self.yaml, self.base_dir, validators)
 
-        if schema is None:
-            return
 
-        if not isinstance(yaml, list):
-            yaml = [yaml]
+def run_validate(schema, yaml, base_dir, validators=None):
+    if schema is None:
+        return
 
-        if base_dir is not None:
-            schema = os.path.join(base_dir, schema)
-            yaml = {os.path.join(base_dir, y) for y in yaml}
+    if not isinstance(yaml, list):
+        yaml = [yaml]
 
-        # Run yaml through glob and flatten list
-        yaml = set(itertools.chain(*map(glob.glob, yaml)))
+    if base_dir is not None:
+        schema = os.path.join(base_dir, schema)
+        yaml = {os.path.join(base_dir, y) for y in yaml}
 
-        # Remove schema from set of data files
-        yaml = yaml - {schema}
+    # Run yaml through glob and flatten list
+    yaml = set(itertools.chain(*map(glob.glob, yaml)))
 
-        yamale_schema = yamale.make_schema(schema, validators=validators)
-        yamale_data = itertools.chain(*map(yamale.make_data, yaml))
+    # Remove schema from set of data files
+    yaml = yaml - {schema}
 
-        for result in yamale.validate(yamale_schema, yamale_data):
-            if not result.isValid():
-                raise ValueError(result)
-        return True
+    yamale_schema = yamale.make_schema(schema, validators=validators)
+    yamale_data = itertools.chain(*map(yamale.make_data, yaml))
+
+    for result in yamale.validate(yamale_schema, yamale_data):
+        if not result.isValid():
+            raise ValueError(result)
+    return True


### PR DESCRIPTION
Multiple issues have over time raised the problem with error messages returned when using either the 'any' or 'subset' validators with multiple includes.

This issue illustrates the problem quite clearly: https://github.com/23andMe/Yamale/issues/159

```yaml
thing: any(include('type_a'), include('type_b'))
---
type_a:
  mode: enum('one')
  one_paramsetX: ...
  one_paramsetY: ...

type_b:
  mode: enum('two')
  two_paramset: ...
```

Such a spec will result in all include validators generating error messages leaving it to the user to figure out which error message is the correct one, which is not exactly ideal.

This PR extends the functionality of the subset and any validators to add a key param:

`any([validators], key='field_name')`
`subset([validators], allow_empty=False, key='field_name')`

- keywords:
    - `key`: Used to limit the validation of includes, the <type> validator will check if the specified field matches whats specified by each include validator before running the validator. 

The above example can then be modified to:
```yaml
thing: any(include('type_a'), include('type_b'), key='mode')
---
type_a:
  mode: enum('one')
  one_paramsetX: ...
  one_paramsetY: ...

type_b:
  mode: enum('two')
  two_paramset: ...
```

The result of this is the ability to greatly reduce the number of error messages produce by Yamale.

The majority of this work is handled by a new method in the schema.py ```_get_include_validators_for_key```

I have tried to keep the pr small, and follow contribution instructions as much as possible but the test setup gave me issues. 

Since this pr is concerned with the error messages produced by Yamale I needed functionality to catch the exception raised and assert against the error message and this is frankly easier with the functional approach pytest seems to be advocating now. 