### PR TITLE
Create .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+-   id: yamale-schema-verify
+    name: check yaml schema with Yamale
+    description: prevents invalid yaml schemas from being committed.
+    entry: yamale
+    language: python
+    types: [yaml]
+    pass_filenames: false
+    stages: [pre-commit, pre-push, manual]


### PR DESCRIPTION
Allows to use Yamale as a pre-commit hook as follows:

```
    - repo: https://github.com/rsrdesarrollo/Yamale
      rev: 'c03ebfc703f557eb5af1b7ef895482b754ce0395'
      hooks:
        - id: yamale-schema-verify
          name: yamale-schema-verify
          files: 'data/.*'
          args: ["-s", "schemas/sample.yaml", "data"]
```