### PR TITLE
pre-commit: set pass_filenames to true

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,8 @@
 -   id: yamale-schema-verify
     name: check yaml schema with Yamale
-    description: prevents invalid yaml schemas from being committed.
+    description: prevents invalid yaml schemas from being committed
     entry: yamale
     language: python
     types: [yaml]
-    pass_filenames: false
+    pass_filenames: true
     stages: [pre-commit, pre-push, manual]


### PR DESCRIPTION
https://github.com/23andMe/Yamale/pull/258 added pre-commit support to Yamale, with `pass_filenames: false`, as only one path is supported at a time.

https://github.com/23andMe/Yamale/pull/251 added support for multiple paths.

Therefore now it is possible to use `pass_filenames: true` with pre-commit.

Sample run (filenames redacted):

```
% pre-commit run --all-files yamale-schema-verify --verbose
check yaml schema with Yamale............................................Passed
- hook id: yamale-schema-verify
- duration: 0.12s

Validating file1.yaml...
Validating file2.yaml...
Validating file3.yaml...
Validating file4.yaml...
Validation success! 👍
[...]
```