### PR TITLE
[codex] Remove eval from schema parser

### DIFF
--- a/yamale/syntax/parser.py
+++ b/yamale/syntax/parser.py
@@ -2,9 +2,6 @@ import ast
 
 from .. import validators as val
 
-safe_globals = ("True", "False", "None")
-safe_builtins = dict((f, __builtins__[f]) for f in safe_globals)
-
 
 def _validate_expr(call_node, validators):
     # Validate that the expression uses a known, registered validator.
@@ -28,12 +25,42 @@ def _validate_expr(call_node, validators):
             raise SyntaxError("Argument values must either be constant literals, or else " "reference other validators.")
 
 
+def _eval_literal(node, validators):
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name) and node.id in validators:
+        return validators[node.id]
+    if isinstance(node, ast.UnaryOp) and isinstance(node.operand, ast.Constant):
+        value = node.operand.value
+        if isinstance(node.op, ast.UAdd):
+            return +value
+        if isinstance(node.op, ast.USub):
+            return -value
+        if isinstance(node.op, ast.Not):
+            return not value
+        if isinstance(node.op, ast.Invert):
+            return ~value
+    if isinstance(node, ast.Call):
+        return _construct_validator(node, validators)
+    raise SyntaxError("Argument values must either be constant literals, or else reference other validators.")
+
+
+def _construct_validator(call_node, validators):
+    func_name = call_node.func.id
+    args = [_eval_literal(arg, validators) for arg in call_node.args]
+    kwargs = {}
+    for keyword in call_node.keywords:
+        if keyword.arg is None:
+            raise SyntaxError("Keyword argument unpacking is not supported.")
+        kwargs[keyword.arg] = _eval_literal(keyword.value, validators)
+    return validators[func_name](*args, **kwargs)
+
+
 def parse(validator_string, validators=None):
     validators = validators or val.DefaultValidators
     try:
         tree = ast.parse(validator_string, mode="eval")
         _validate_expr(tree.body, validators)
-        # evaluate with access to a limited global scope only
-        return eval(compile(tree, "<ast>", "eval"), {"__builtins__": safe_builtins}, validators)
+        return _construct_validator(tree.body, validators)
     except (SyntaxError, NameError, TypeError) as e:
         raise SyntaxError("Invalid schema expression: '%s'. " % validator_string + str(e))

--- a/yamale/syntax/tests/test_parser.py
+++ b/yamale/syntax/tests/test_parser.py
@@ -1,23 +1,7 @@
 from pytest import raises
 
 from .. import parser as par
-from yamale.validators.validators import (
-    Validator,
-    String,
-    Regex,
-    Number,
-    Integer,
-    Boolean,
-    List,
-    Day,
-    Timestamp,
-    Ip,
-    Mac,
-)
-
-
-def test_eval():
-    assert eval("String()") == String()
+from yamale.validators.validators import Validator, String, Regex, Number, Integer, Boolean, List, Day, Timestamp, Ip, Mac
 
 
 def test_types():
@@ -32,6 +16,16 @@ def test_types():
     assert par.parse("list(str())") == List(String())
     assert par.parse("ip()") == Ip()
     assert par.parse("mac()") == Mac()
+
+
+def test_nested_type_reference():
+    parsed = par.parse("list(list(num, min=2, max=2), min=2, max=2)")
+    assert parsed == List(List(Number, min=2, max=2), min=2, max=2)
+
+
+def test_unary_constants():
+    parsed = par.parse("num(min=-1, max=+1)")
+    assert parsed == Number(min=-1, max=1)
 
 
 def test_custom_type():


### PR DESCRIPTION
## Summary
- replace the final schema parser `eval(compile(...))` step with a recursive AST constructor
- keep the existing validated grammar for constants, validator-name references, and nested validator calls
- add parser regression coverage for nested validator-name references and unary numeric constants

## Rationale
PR #173 added AST validation as a best-effort hardening step and noted that removing `eval` entirely would be the stronger follow-up. This keeps the same schema syntax while avoiding runtime evaluation of schema expressions.

## Validation
- `pytest yamale` (169 passed)
- `ruff check yamale/syntax/parser.py yamale/syntax/tests/test_parser.py`
- `bandit yamale/syntax/parser.py -q`