### PR TITLE
fix: raise ValueError on malformed YAML instead of leaking the parser's exception (#282)

### DIFF
--- a/yamale/readers/tests/test_bad_file.py
+++ b/yamale/readers/tests/test_bad_file.py
@@ -9,3 +9,11 @@ parsers = ["pyyaml", "PyYAML", "ruamel"]
 def test_reader_error(parser):
     with raises(IOError):
         parse_yaml("wat", parser)
+
+
+@pytest.mark.parametrize("parser", parsers)
+def test_malformed_yaml_raises_value_error(parser):
+    # Malformed YAML should surface as a clean ValueError instead of leaking
+    # the underlying parser's ScannerError/YAMLError as a stack trace (#282).
+    with raises(ValueError):
+        parse_yaml(content='key: "unclosed', parser=parser)

--- a/yamale/readers/yaml_reader.py
+++ b/yamale/readers/yaml_reader.py
@@ -9,14 +9,20 @@ def _pyyaml(f):
         Loader = yaml.CSafeLoader
     except AttributeError:  # System does not have libyaml
         Loader = yaml.SafeLoader
-    return list(yaml.load_all(f, Loader=Loader))
+    try:
+        return list(yaml.load_all(f, Loader=Loader))
+    except yaml.YAMLError as e:
+        raise ValueError("Could not parse YAML: {}".format(e)) from e
 
 
 def _ruamel(f):
-    from ruamel.yaml import YAML
+    from ruamel.yaml import YAML, YAMLError
 
     yaml = YAML(typ="safe")
-    return list(yaml.load_all(f))
+    try:
+        return list(yaml.load_all(f))
+    except YAMLError as e:
+        raise ValueError("Could not parse YAML: {}".format(e)) from e
 
 
 _parsers = {"pyyaml": _pyyaml, "ruamel": _ruamel}


### PR DESCRIPTION
## Problem
Fixes #282. When `parse_yaml` is given malformed YAML, the underlying parser's exception (PyYAML's `yaml.scanner.ScannerError` / ruamel's `YAMLError`) escapes as a raw stack trace instead of a clean error. Confirmed on master HEAD `5046af8`.

## Root cause
`_pyyaml` and `_ruamel` in `yamale/readers/yaml_reader.py` call `yaml.load_all(...)` without catching the parser's error, so it propagates straight out of `parse_yaml`.

## Fix
Wrap each parser's `load_all` call in a try/except for its own error type (`yaml.YAMLError` for PyYAML, `ruamel.yaml.YAMLError` for ruamel) and re-raise as `ValueError` with the original message chained via `from e`. No API change; ~8 lines.

## How to test
```python
from yamale.readers import parse_yaml
parse_yaml(content='key: "unclosed', parser='pyyaml')
# before: yaml.scanner.ScannerError: while scanning a quoted scalar ... (stack trace)
# after:  ValueError: Could not parse YAML: while scanning a quoted scalar ...
```
Regression test added in `yamale/readers/tests/test_bad_file.py`, parametrized over pyyaml/PyYAML/ruamel. Full suite green (171 passed).

## Backward compatibility
No breaking changes. Only the exception type for malformed input changes (raw parser error -> `ValueError`), which is the behavior requested in #282.

---
Assisted-by: Claude (code generation, reviewed and tested locally)